### PR TITLE
required_pull_request_reviews can not be set on private repositories

### DIFF
--- a/src/modules/github-repository/main.tf
+++ b/src/modules/github-repository/main.tf
@@ -107,13 +107,17 @@ resource "github_branch_protection" "protection" {
     strict = each.value.required_status_checks.strict
   }
 
-  required_pull_request_reviews {
-    dismiss_stale_reviews           = each.value.required_pull_request_reviews.dismiss_stale_reviews
-    restrict_dismissals             = each.value.required_pull_request_reviews.restrict_dismissals
-    require_code_owner_reviews      = var.visibility == "public" ? each.value.required_pull_request_reviews.require_code_owner_reviews : null
-    required_approving_review_count = each.value.required_pull_request_reviews.required_approving_review_count
-    dismissal_restrictions          = each.value.required_pull_request_reviews.dismissal_restrictions
-    pull_request_bypassers          = each.value.required_pull_request_reviews.pull_request_bypassers
+  dynamic "required_pull_request_reviews" {
+    for_each = toset(var.visibility == "public" ? ["rules"] : [])
+
+    content {
+      dismiss_stale_reviews           = each.value.required_pull_request_reviews.dismiss_stale_reviews
+      restrict_dismissals             = each.value.required_pull_request_reviews.restrict_dismissals
+      require_code_owner_reviews      = each.value.required_pull_request_reviews.require_code_owner_reviews
+      required_approving_review_count = each.value.required_pull_request_reviews.required_approving_review_count
+      dismissal_restrictions          = each.value.required_pull_request_reviews.dismissal_restrictions
+      pull_request_bypassers          = each.value.required_pull_request_reviews.pull_request_bypassers
+    }
   }
 
   depends_on = [
@@ -161,6 +165,6 @@ resource "github_repository_file" "CODEOWNERS" {
   commit_message      = "Provisioned by Terraform"
   commit_email        = "automation@arrowair.com"
   commit_author       = "Arrow automation"
-  overwrite_on_create = false
+  overwrite_on_create = true
   depends_on          = [github_repository_environment.env]
 }


### PR DESCRIPTION
Some of the branch protection rules are limited to public repositories only. It's not completely clear during the plan step if the rules are allowed to be applied or not.
I can't find the list of allowed rules for private repositories in the [Terraform provider docs](https://registry.terraform.io/providers/integrations/github/latest/docs/resources/branch_protection) either, but I'm going to assume we're not allowed to set any of the settings in the `required_pull_request_reviews` setting.

In addition, I've set the CODEOWNERS file to allow override if it already exists. I think it's fine to keep this managed by Terraform.