### PR TITLE
Bugfix: repository template name

### DIFF
--- a/src/modules/github-repository/main.tf
+++ b/src/modules/github-repository/main.tf
@@ -30,7 +30,7 @@ resource "github_repository" "repository" {
 
     content {
       owner      = "Arrow-air"
-      repository = template.key
+      repository = template.value
     }
   }
 }


### PR DESCRIPTION
When a template name is being passed to the repository module, we were using a `for_each` loop to detect if the template block needs to be set.
This loop generates a list of strings, where the iterator `key` will be the list index. We should instead use the iterator `value` to get the template name.