### PR TITLE
Template repository branch protections

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,38 @@
 # tf-github
-Terraform code to create github resources
+
+Terraform code to manage GitHub repositories.
+Resources currently managed by this repository are:
+ * GitHub repositories
+ * Repository branch protections
+ * Repository permissions
+ * Generic files for multiple repositories
+
+## CICD
+
+To deploy changes from this repository, we've installed a Terraform app to provide authentication for the Terraform actions performed on the GitHub resources.
+
+Multiple secrets have been created in the repository settings itself, which are needed to run the GitHub Actions:
+| Secret                                  | Description                                                                                                            |
+| --------------------------------------- | -----------------------------------------------------------------------------------------------------------------------|
+| TF_CLOUD_TOKEN                          | Used to authenticate with Terraform Cloud for state management                                                         |
+| TF_GITHUB_APP_PEM_FILE                  | Needed to allow managing of GitHub resources through the Terraform app installed on the Arrow-air Github Organization. |
+| TF_VAR_DISCORD_SERVICES_INTEGRATION_URL | Variable needed by Terraform containing the `services` team discord integration URL.                                   |
+
+Each PR will trigger a workflow to output the Terraform plan. This plan should always be checked before merging to `main`.
+As soon as the PR is merged to `main`, a workflow will run to deploy the changes with Terraform.
+
+# Repository management
+
+All repositories are created through the internal `github-repository` module, allowing for easy management of branch protections, files and webhooks.
+Repositories that require similar settings, are grouped into seperate files. The configurations provided by these `repositories_*.tf` files also enforce naming conventions.
+
+The following repository types are currently pre-defined:
+ * `tf`  -- Repositories containing Terraform code
+ * `lib-<name>-rust` -- Repositories for the Arrow libraries written in Rust
+ * `svc-<name>-rust` -- Repositories for the Arrow services written in Rust
+ * `lib-template-<lang>` -- Repository templates for Arrow libraries
+ * `svc-template-<lang>` -- Repository templates for Arrow services
+
+## Adding a new repository
+
+:construction: Coming Soon :construction:

--- a/src/main.tf
+++ b/src/main.tf
@@ -2,6 +2,23 @@ locals {
   # Secret provided by Terraform Cloud configuration on the workspace
   discord_services_integration_url = sensitive(var.discord_services_integration_url)
 
+  # List of webhooks to apply for repositories owned by team
+  webhooks = {
+    services = {
+      "discord" = {
+        events = [
+          "pull_request",
+          "pull_request_review",
+          "pull_request_review_comment",
+          "pull_request_review_thread"
+        ]
+        configuration = {
+          url = local.discord_services_integration_url
+        }
+      }
+    }
+  }
+
   repos = {
     "website" = {
       default_branch = "staging"

--- a/src/modules/github-repository/main.tf
+++ b/src/modules/github-repository/main.tf
@@ -87,6 +87,8 @@ resource "github_branch" "branch" {
 resource "github_branch_default" "default" {
   repository = github_repository.repository.name
   branch     = var.default_branch
+
+  depends_on = [github_branch.branch]
 }
 
 resource "github_branch_protection" "protection" {

--- a/src/moved.tf
+++ b/src/moved.tf
@@ -1,0 +1,92 @@
+#################################################
+#
+# Temporary file to tell Terraform some resources
+# have been renamed in the state.
+# Can be removed after apply
+#
+#################################################
+
+moved {
+  from = github_repository.lib_template_rust
+  to   = module.repository_lib_template["rust"].github_repository.repository
+}
+moved {
+  from = github_repository.svc_template_python
+  to   = module.repository_svc_template["python"].github_repository.repository
+}
+moved {
+  from = github_repository.svc_template_rust
+  to   = module.repository_svc_template["rust"].github_repository.repository
+}
+moved {
+  from = github_repository.svc_template_typescript
+  to   = module.repository_svc_template["typescript"].github_repository.repository
+}
+moved {
+  from = github_team_repository.lib_template_rust_maintainer
+  to   = module.repository_lib_template["rust"].github_team_repository.maintainer["services"]
+}
+moved {
+  from = github_team_repository.svc_template_python_maintainer
+  to   = module.repository_svc_template["python"].github_team_repository.maintainer["services"]
+}
+moved {
+  from = github_team_repository.svc_template_rust_maintainer
+  to   = module.repository_svc_template["rust"].github_team_repository.maintainer["services"]
+}
+moved {
+  from = github_team_repository.svc_template_typescript_maintainer
+  to   = module.repository_svc_template["typescript"].github_team_repository.maintainer["services"]
+}
+moved {
+  from = module.tf_repository["github"].github_branch_default.default
+  to   = module.repository_tf["github"].github_branch_default.default
+}
+moved {
+  from = module.tf_repository["github"].github_branch_protection.all["tf-github"]
+  to   = module.repository_tf["github"].github_branch_protection.all["tf-github"]
+}
+moved {
+  from = module.tf_repository["github"].github_branch_protection.protection["main"]
+  to   = module.repository_tf["github"].github_branch_protection.protection["main"]
+}
+moved {
+  from = module.tf_repository["github"].github_repository.repository
+  to   = module.repository_tf["github"].github_repository.repository
+}
+moved {
+  from = module.tf_repository["github"].github_repository_file.CODEOWNERS
+  to   = module.repository_tf["github"].github_repository_file.CODEOWNERS
+}
+moved {
+  from = module.tf_repository["github"].github_repository_webhook.map["discord"]
+  to   = module.repository_tf["github"].github_repository_webhook.map["discord"]
+}
+moved {
+  from = module.tf_repository["github"].github_team_repository.maintainer["devops"]
+  to   = module.repository_tf["github"].github_team_repository.maintainer["devops"]
+}
+moved {
+  from = module.tf_repository["github"].github_team_repository.maintainer["services"]
+  to   = module.repository_tf["github"].github_team_repository.maintainer["services"]
+}
+moved {
+  from = module.tf_repository["onboarding"].github_branch_default.default
+  to   = module.repository_tf["onboarding"].github_branch_default.default
+}
+moved {
+  from = module.tf_repository["onboarding"].github_repository.repository
+  to   = module.repository_tf["onboarding"].github_repository.repository
+}
+moved {
+  from = module.tf_repository["onboarding"].github_repository_file.CODEOWNERS
+  to   = module.repository_tf["onboarding"].github_repository_file.CODEOWNERS
+}
+moved {
+  from = module.tf_repository["onboarding"].github_repository_webhook.map["discord"]
+  to   = module.repository_tf["onboarding"].github_repository_webhook.map["discord"]
+}
+moved {
+  from = module.tf_repository["onboarding"].github_team_repository.maintainer["devops"]
+  to   = module.repository_tf["onboarding"].github_team_repository.maintainer["devops"]
+}

--- a/src/repositories_rust.tf
+++ b/src/repositories_rust.tf
@@ -4,24 +4,47 @@
 #
 #####################################################################
 locals {
-
-  rust_default = {
-
-    # List of webhooks to apply for all services repositories
-    webhooks = {
-      "discord" = {
-        events = [
-          "pull_request",
-          "pull_request_review",
-          "pull_request_review_comment",
-          "pull_request_review_thread"
-        ]
-        configuration = {
-          url = local.discord_services_integration_url
+  rust_lib = {
+    files = merge(
+      local.rust_default.files,
+      {
+        ".gitignore" = {
+          content = file("templates/rust-lib/.gitignore")
         }
       }
-    }
+    )
 
+    repos = {
+      "router" = {
+        description = "Fleet Routing Algorithm Library"
+      }
+      #   "analytics" = {
+      #     description = "Fleet Routing Analysis from Real or Simulated Artifacts"
+      #   }
+    }
+  }
+
+  rust_svc = {
+    files = merge(
+      local.rust_default.files,
+      {
+        ".gitignore" = {
+          content = file("templates/rust-svc/.gitignore")
+        }
+      }
+    )
+
+    repos = {
+      "storage" = {
+        description = "Storage module"
+      },
+      "scheduler" = {
+        description = "Fleet Routing and Flight Planner"
+      }
+    }
+  }
+
+  rust_default = {
     files = {
       ".editorconfig" = {
         content = file("templates/rust-all/.editorconfig")
@@ -48,126 +71,55 @@ locals {
         content = file("templates/rust-all/.github/workflows/editorconfig_check.yml")
       }
     }
-  }
 
-  lib = {
-    repository_prefix  = "lib"
-    description_prefix = "Arrow Libraries"
-
-    webhooks = local.rust_default.webhooks
-
-    files = merge(
-      local.rust_default.files,
-      {
-        ".gitignore" = {
-          content = file("templates/rust-lib/.gitignore")
-        }
-    })
-
-    # List of library repositories to be created
-    # Default settings without override
-    # {
-    #   name           = "<repository_prefix>-<lib_template_repos key>"
-    #   description    = "<description_prefix> - <description>"
-    # }
-    # Default settings (can be overwritten here)
-    # {
-    #   owner_team     = "services"
-    #   visibility     = "public"
-    #   default_branch = "dev"
-    #   template       = github_repository.lib_template_rust.name
-    #   webhooks       = local.lib.webhooks
-    #   default_branch_protection_settings = {} # Using module defaults
-    # }
-    repos = {
-      "router" = {
-        description = "Fleet Routing Algorithm Library"
-      }
-      #   "analytics" = {
-      #     description = "Fleet Routing Analysis from Real or Simulated Artifacts"
-      #   }
-    }
-  }
-
-  svc = {
-    repository_prefix  = "svc"
-    description_prefix = "Arrow Services"
-
-    webhooks = local.rust_default.webhooks
-
-    files = merge(
-      local.rust_default.files,
-      {
-        ".gitignore" = {
-          content = file("templates/rust-svc/.gitignore")
-        }
-    })
-
-    # List of service repositories to be created
-    # Default settings without override
-    # {
-    #   name           = "<repository_prefix>-<svc_template_repos key>"
-    #   description    = "<description_prefix> - <description>"
-    # }
-    # Default settings (can be overwritten here)
-    # {
-    #   owner_team     = "services"
-    #   visibility     = "public"
-    #   default_branch = "dev"
-    #   template       = github_repository.svc_template_rust.name
-    #   webhooks       = local.svc.webhooks
-    #   default_branch_protection_settings = {} # Using module defaults
-    # }
-    repos = {
-      "storage" = {
-        description = "Storage module"
-      },
-      "scheduler" = {
-        description = "Fleet Routing and Flight Planner"
-      }
+    settings = {
+      owner_team                         = "services"
+      visibility                         = "public"
+      default_branch                     = "develop"
+      webhooks                           = try(local.webhooks["services"], {})
+      default_branch_protection_settings = {} # Using module defaults
     }
   }
 }
 
 ########################################################
-# Library repositories
+# Rust Library repositories
 ########################################################
 module "repository_rust_lib" {
   source   = "./modules/github-repository/"
-  for_each = local.lib.repos
+  for_each = { for key, settings in local.rust_lib.repos : key => merge(local.rust_default.settings, settings) }
 
-  name        = format("%s-%s", local.lib.repository_prefix, each.key)
-  description = format("%s - %s", local.lib.description_prefix, each.value.description)
+  name             = format("lib-%s", each.key)
+  description      = format("Arrow Library - %s", each.value.description)
+  template         = module.repository_lib_template["rust"].repository.name
+  repository_files = local.rust_lib.files
 
   # Settings with defaults
-  owner_team       = try(each.value.owner_team, "services")
-  visibility       = try(each.value.visibility, "public")
-  default_branch   = try(each.value.default_branch, "develop")
-  template         = github_repository.lib_template_rust.name
-  webhooks         = local.lib.webhooks
-  repository_files = local.lib.files
+  owner_team     = each.value.owner_team
+  visibility     = each.value.visibility
+  default_branch = each.value.default_branch
+  webhooks       = each.value.webhooks
 
-  default_branch_protection_settings = try(each.value.default_branch_protection_settings, {})
+  default_branch_protection_settings = each.value.default_branch_protection_settings
 }
 
 ########################################################
-# Services repositories
+# Rust Services repositories
 ########################################################
 module "repository_rust_svc" {
   source   = "./modules/github-repository/"
-  for_each = local.svc.repos
+  for_each = { for key, settings in local.rust_svc.repos : key => merge(local.rust_default.settings, settings) }
 
-  name        = format("%s-%s", local.svc.repository_prefix, each.key)
-  description = format("%s - %s", local.svc.description_prefix, each.value.description)
+  name             = format("svc-%s", each.key)
+  description      = format("Arrow Service - %s", each.value.description)
+  template         = module.repository_svc_template["rust"].repository.name
+  repository_files = local.rust_svc.files
 
   # Settings with defaults
-  owner_team       = try(each.value.owner_team, "services")
-  visibility       = try(each.value.visibility, "public")
-  default_branch   = try(each.value.default_branch, "develop")
-  template         = github_repository.svc_template_rust.name
-  webhooks         = local.svc.webhooks
-  repository_files = local.svc.files
+  owner_team     = each.value.owner_team
+  visibility     = each.value.visibility
+  default_branch = each.value.default_branch
+  webhooks       = each.value.webhooks
 
-  default_branch_protection_settings = try(each.value.default_branch_protection_settings, {})
+  default_branch_protection_settings = each.value.default_branch_protection_settings
 }
-

--- a/src/repositories_templates.tf
+++ b/src/repositories_templates.tf
@@ -1,91 +1,79 @@
-########################################################
+#####################################################################
 #
-# TypeScript template repository
+# Repository settings for Arrow Templates
 #
-########################################################
-resource "github_repository" "svc_template_typescript" {
-  name        = "svc-template-typescript"
-  description = "Arrow Service repository template for TypeScript services"
-  visibility  = "public"
+#####################################################################
 
-  auto_init            = true
-  has_issues           = true
-  has_projects         = true
-  has_wiki             = true
-  vulnerability_alerts = true
-  is_template          = true
-}
-resource "github_team_repository" "svc_template_typescript_maintainer" {
-  repository = github_repository.svc_template_typescript.name
-  team_id    = "services"
-  permission = "maintain"
-}
+locals {
+  lib_template = {
+    repos = {
+      "rust" = {
+        description = "Rust libraries"
+      }
+    }
+  }
 
-########################################################
-#
-# Rust Service template repository
-#
-########################################################
-resource "github_repository" "svc_template_rust" {
-  name        = "svc-template-rust"
-  description = "Arrow Service repository template for Rust services"
-  visibility  = "public"
+  svc_template = {
+    repos = {
+      "typescript" = {
+        description = "TypeScript services"
+      }
+      "rust" = {
+        description = "Rust services"
+      }
+      "python" = {
+        description = "Python services"
+      }
+    }
+  }
 
-  auto_init            = true
-  has_issues           = true
-  has_projects         = true
-  has_wiki             = true
-  vulnerability_alerts = true
-  is_template          = true
-}
-resource "github_team_repository" "svc_template_rust_maintainer" {
-  repository = github_repository.svc_template_rust.name
-  team_id    = "services"
-  permission = "maintain"
+  template_default = {
+    settings = {
+      owner_team                         = "services"
+      visibility                         = "public"
+      default_branch                     = "develop"
+      webhooks                           = try(local.webhooks["services"], {})
+      default_branch_protection_settings = {} # Using module defaults
+    }
+  }
 }
 
 ########################################################
-#
-# Rust Library template repository
-#
+# Library repositories
 ########################################################
-resource "github_repository" "lib_template_rust" {
-  name        = "template-rust-lib"
-  description = "Arrow (Rust) Library Repository"
-  visibility  = "public"
+module "repository_lib_template" {
+  source   = "./modules/github-repository/"
+  for_each = { for key, settings in local.lib_template.repos : key => merge(local.template_default.settings, settings) }
 
-  auto_init            = true
-  has_issues           = true
-  has_projects         = true
-  has_wiki             = true
-  vulnerability_alerts = true
-  is_template          = true
-}
-resource "github_team_repository" "lib_template_rust_maintainer" {
-  repository = github_repository.lib_template_rust.name
-  team_id    = "services"
-  permission = "maintain"
+  name        = format("lib-template-%s", each.key)
+  description = format("Arrow Library Template - %s", each.value.description)
+  is_template = true
+
+  # Settings with defaults
+  owner_team     = each.value.owner_team
+  visibility     = each.value.visibility
+  default_branch = each.value.default_branch
+  webhooks       = each.value.webhooks
+
+  default_branch_protection_settings = each.value.default_branch_protection_settings
 }
 
 ########################################################
-#
-# Python template repository
-#
+# Services repositories
 ########################################################
-resource "github_repository" "svc_template_python" {
-  name        = "svc-template-python"
-  description = "Arrow Service repository template for Python services"
-  visibility  = "public"
+module "repository_svc_template" {
+  source   = "./modules/github-repository/"
+  for_each = { for key, settings in local.svc_template.repos : key => merge(local.template_default.settings, settings) }
 
-  auto_init            = true
-  has_issues           = true
-  has_projects         = true
-  has_wiki             = true
-  vulnerability_alerts = true
-  is_template          = true
-}
-resource "github_team_repository" "svc_template_python_maintainer" {
-  repository = github_repository.svc_template_python.name
-  team_id    = "services"
-  permission = "maintain"
+  name        = format("svc-template-%s", each.key)
+  description = format("Arrow Service Template - %s", each.value.description)
+  is_template = true
+
+  # Settings with defaults
+  owner_team     = each.value.owner_team
+  visibility     = each.value.visibility
+  default_branch = each.value.default_branch
+  webhooks       = each.value.webhooks
+
+  default_branch_protection_settings = each.value.default_branch_protection_settings
 }


### PR DESCRIPTION
- Use the module to create template repositories
- Some re-organization of the repositories_*.tf files to make it easier to find the 'repos' key to create new repositories
- Started on the README.md