### PR TITLE
Allow Terraform bot to make commits without signing

### DIFF
--- a/src/modules/github-repository/variables.tf
+++ b/src/modules/github-repository/variables.tf
@@ -66,7 +66,7 @@ variable "protected_branches" {
 
   type = map(object({
     pattern                         = optional(string)
-    enforce_admins                  = optional(bool, true)
+    enforce_admins                  = optional(bool, false)
     allows_deletions                = optional(bool, false)
     allows_force_pushes             = optional(bool, false)
     require_conversation_resolution = optional(bool, true)
@@ -127,7 +127,7 @@ variable "default_branch_protection_settings" {
   description = "Settings to use for protected branches created"
 
   type = object({
-    enforce_admins                  = optional(bool, true)
+    enforce_admins                  = optional(bool, false)
     allows_deletions                = optional(bool, false)
     allows_force_pushes             = optional(bool, false)
     require_conversation_resolution = optional(bool, true)
@@ -162,7 +162,7 @@ variable "default_branch_protection_settings" {
   })
 
   default = {
-    enforce_admins                  = true
+    enforce_admins                  = false
     allows_deletions                = false
     allows_force_pushes             = false
     require_conversation_resolution = true


### PR DESCRIPTION
Since we've enforced signed commits on all branches, we can't push through any file changes made with Terraform since the Terraform bot isn't able to sign the commits. (See: https://github.com/Arrow-air/tf-github/runs/8096966295?check_suite_focus=true#step:10:948)
One option is to allow administrators to bypass the branch protections which is part of this PR.
Currently, we don't provide administrator permissions to anyone except Terraform.