### PR TITLE
Fix ci issues

### DIFF
--- a/src/templates/rust-all/.editorconfig
+++ b/src/templates/rust-all/.editorconfig
@@ -19,7 +19,7 @@ indent_size = off
 trim_trailing_whitespace = false
 [*.yml]
 indent_size = 2
-[Makefile]
+[Makefile*]
 indent_style = tab
 indent_size = 4
 

--- a/src/templates/rust-all/.github/workflows/editorconfig_check.yml
+++ b/src/templates/rust-all/.github/workflows/editorconfig_check.yml
@@ -3,6 +3,9 @@
 
 name: EditorConfig Check
 
+env:
+  TERM: xterm
+
 on:
   push:
     branches:
@@ -12,7 +15,7 @@ on:
 jobs:
   codestyle:
     name: Code Style
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
       - run: make editorconfig-test

--- a/src/templates/rust-all/.github/workflows/pr_rebase.yml
+++ b/src/templates/rust-all/.github/workflows/pr_rebase.yml
@@ -1,7 +1,17 @@
+## DO NOT EDIT!
+# This file was provisioned by Terraform
+# Check file validity at: https://rhysd.github.io/actionlint/
+# https://github.com/actions/virtual-environments/blob/main/images/linux/Ubuntu2004-Readme.md
+
 name: PR Rebase
+
+env:
+  TERM: xterm
+
 on:
   issue_comment:
     types: [created]
+
 jobs:
   rebase:
     name: Rebase

--- a/src/templates/rust-all/.github/workflows/python_ci.yml
+++ b/src/templates/rust-all/.github/workflows/python_ci.yml
@@ -11,10 +11,13 @@ on:
 
 name: Python Checks
 
+env:
+  TERM: xterm
+
 jobs:
   formatting-check:
     name: Formatting Check
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
       - run: make python-test

--- a/src/templates/rust-all/.github/workflows/rust_ci.yml
+++ b/src/templates/rust-all/.github/workflows/rust_ci.yml
@@ -24,7 +24,7 @@ jobs:
 
   build_and_test_debug:
     name: Build & Test
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
       - name: Build
@@ -35,14 +35,14 @@ jobs:
 
   fmt:
     name: Rustfmt
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
       - run: make rust-fmt
 
   clippy:
     name: Clippy
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
       - run: make rust-clippy

--- a/src/templates/rust-all/Makefile.tftpl
+++ b/src/templates/rust-all/Makefile.tftpl
@@ -43,45 +43,45 @@ build: check-cargo-registry
 test: rust-check rust-test rust-clippy rust-fmt toml-test python-test
 
 rust-check: check-cargo-registry
-    @echo "$(YELLOW)Finding manifest-path for cargo...$(NC)"
+	@echo "$(YELLOW)Finding manifest-path for cargo...$(NC)"
 ifeq ("$(CARGO_MANIFEST_PATH)", "")
-    @echo "$(BOLD)$(YELLOW)No Cargo.toml found in any of the subdirectories, skipping cargo check...$(NC)$(NC)"
+	@echo "$(BOLD)$(YELLOW)No Cargo.toml found in any of the subdirectories, skipping cargo check...$(NC)$(NC)"
 else
-    @echo "$(YELLOW)Running cargo check...$(NC)"
-    @$(call docker_run,cargo check --manifest-path "$(CARGO_MANIFEST_PATH)")
+	@echo "$(YELLOW)Running cargo check...$(NC)"
+	@$(call docker_run,cargo check --manifest-path "$(CARGO_MANIFEST_PATH)")
 endif
 
 rust-test: check-cargo-registry
-    @echo "$(YELLOW)Finding manifest-path for cargo...$(NC)"
+	@echo "$(YELLOW)Finding manifest-path for cargo...$(NC)"
 ifeq ("$(CARGO_MANIFEST_PATH)", "")
-    @echo "$(BOLD)$(YELLOW)No Cargo.toml found in any of the subdirectories, skipping cargo tests...$(NC)$(NC)"
+	@echo "$(BOLD)$(YELLOW)No Cargo.toml found in any of the subdirectories, skipping cargo tests...$(NC)$(NC)"
 else
-    @echo "$(YELLOW)Running cargo tests...$(NC)"
-    @$(call docker_run,cargo test --manifest-path "$(CARGO_MANIFEST_PATH)" --all)
+	@echo "$(YELLOW)Running cargo tests...$(NC)"
+	@$(call docker_run,cargo test --manifest-path "$(CARGO_MANIFEST_PATH)" --all)
 endif
 
 rust-clippy: check-cargo-registry
 ifeq ("$(CARGO_MANIFEST_PATH)", "")
-    @echo "$(BOLD)$(YELLOW)No Cargo.toml found in any of the subdirectories, skipping cargo clippy...$(NC)$(NC)"
+	@echo "$(BOLD)$(YELLOW)No Cargo.toml found in any of the subdirectories, skipping cargo clippy...$(NC)$(NC)"
 else
-    @echo "$(YELLOW)Linting Rust codes through clippy...$(NC)"
-    @$(call docker_run,cargo clippy --manifest-path "$(CARGO_MANIFEST_PATH)" --all -- -D warnings)
+	@echo "$(YELLOW)Linting Rust codes through clippy...$(NC)"
+	@$(call docker_run,cargo clippy --manifest-path "$(CARGO_MANIFEST_PATH)" --all -- -D warnings)
 endif
 
 rust-fmt: check-cargo-registry
 ifeq ("$(CARGO_MANIFEST_PATH)", "")
-    @echo "$(BOLD)$(YELLOW)No Cargo.toml found in any of the subdirectories, skipping cargo fmt...$(NC)$(NC)"
+	@echo "$(BOLD)$(YELLOW)No Cargo.toml found in any of the subdirectories, skipping cargo fmt...$(NC)$(NC)"
 else
-    @echo "$(YELLOW)Running and checking Rust codes formats...$(NC)"
-    @$(call docker_run,cargo fmt --manifest-path "$(CARGO_MANIFEST_PATH)" --all -- --check)
+	@echo "$(YELLOW)Running and checking Rust codes formats...$(NC)"
+	@$(call docker_run,cargo fmt --manifest-path "$(CARGO_MANIFEST_PATH)" --all -- --check)
 endif
 
 rust-tidy: check-cargo-registry
 ifeq ("$(CARGO_MANIFEST_PATH)", "")
-    @echo "$(BOLD)$(YELLOW)No Cargo.toml found in any of the subdirectories, skipping cargo fmt...$(NC)$(NC)"
+	@echo "$(BOLD)$(YELLOW)No Cargo.toml found in any of the subdirectories, skipping cargo fmt...$(NC)$(NC)"
 else
-    @echo "$(YELLOW)Running rust file formatting fixes...$(NC)"
-    @$(call docker_run,cargo fmt --all)
+	@echo "$(YELLOW)Running rust file formatting fixes...$(NC)"
+	@$(call docker_run,cargo fmt --all)
 endif
 
 rust-tidy: check-cargo-registry
@@ -104,7 +104,7 @@ python-test:
 
 python-tidy:
 	@echo "$(YELLOW)Running python file formatting fixes...$(NC)"
-	@$(call docker_run,black--extend-exclude .cargo .)
+	@$(call docker_run,black --extend-exclude .cargo .)
 
 editorconfig-test:
 	@echo "$(YELLOW)Checking if the codebase is compliant with the .editorconfig file...$(NC)"


### PR DESCRIPTION
Not all ci files are setting the TERM env making the ci job fail on the `make` step.
Due to the Makefile being a template and not being matched correctly, the .editorconfig file changes all tabs into spaces.