### PR TITLE
Add svc-cargo

### DIFF
--- a/src/repositories_rust.tf
+++ b/src/repositories_rust.tf
@@ -26,6 +26,9 @@ locals {
       },
       "scheduler" = {
         description = "Fleet Routing and Flight Planner"
+      },
+      "cargo" = {
+        description = "Public Requests for Cargo Services"
       }
     }
   }


### PR DESCRIPTION
More information in Services CONOPS

svc-scheduler is a busy bee and should not be directly handling requests from customers

svc-cargo, svc-rideshare, and svc-charter will handle these requests from web and mobile apps. They will handle the back and forth with customers, confirming flights, etc.

May also grab information about the aircraft, components, etc. if the customer requests it, so these requests don't go directly to svc-storage