### PR TITLE
Add DS_Store in gitignore template

### DIFF
--- a/src/templates/rust-all/.gitignore.tftpl
+++ b/src/templates/rust-all/.gitignore.tftpl
@@ -22,3 +22,6 @@ Cargo.lock
 
 # Don't add vscode meta files
 .vscode
+
+# Don't add DS_Store
+.DS_Store


### PR DESCRIPTION
We need to exclude .DS_Store files for contributors working with MacOS.