### PR TITLE
fix(rust-all): use 'test' target in pre-commit

### DIFF
--- a/src/repositories_rust.tf
+++ b/src/repositories_rust.tf
@@ -140,7 +140,7 @@ module "repository_rust_svc" {
         content = templatefile(path, {
           owner_team = each.value.owner_team
           type       = "svc"
-          name       = format("lib-%s", each.key)
+          name       = format("svc-%s", each.key)
           port       = format("80%02.0f", index(keys(local.rust_svc.repos), each.key))
         })
       }

--- a/src/templates/rust-all/.cargo-husky/hooks/pre-commit
+++ b/src/templates/rust-all/.cargo-husky/hooks/pre-commit
@@ -17,14 +17,8 @@ echo -e "${BOLD}${YELLOW}Running the pre-commit hook...${NC}${SGR0}"
 
 set -e
 
-# RUST
-make rust-test
-
-# PYTHON 3
-make python-test
-
-# TOML formatting
-make toml-test
+# Tests
+make test
 
 # Style Check
 make editorconfig-test


### PR DESCRIPTION
Using the `test` target will make sure all tests are being run which are also tested by the github action.

In addition, fixed a bug where the file templates were given the wrong `name` for new rust service projects.