### PR TITLE
:hatching_chick: Create ATC software library

### DIFF
--- a/src/main.tf
+++ b/src/main.tf
@@ -88,6 +88,14 @@ locals {
       webhooks         = try(local.webhooks["services"], {})
       repository_files = local.rust_default.files
     }
+    "atc-core" = {
+      description      = "Air Traffic Control Library for UAM Activities"
+      visibility       = "public"
+      owner_team       = "services"
+      default_branch   = "develop"
+      webhooks         = try(local.webhooks["services"], {})
+      repository_files = local.rust_default.files
+    }
   }
 }
 


### PR DESCRIPTION
`atc-core` is the central library of Air Traffic Control (ATC) assets, UI elements, etc.

There is a goal to produce a video game alongside the actual ATC software, to act as a training and recruitment tool. The game would be disconnected from any real operations, but would feature up-to-date interfaces from real ATC software.

To that end, this crate is a  _library_ and not a binary. Binary crates `atc-game` and `atc-real` (actual name TBD) will import this library to populate interfaces.