### PR TITLE
fix: Create repo from template

### DIFF
--- a/src/modules/github-repository/variables.tf
+++ b/src/modules/github-repository/variables.tf
@@ -4,6 +4,12 @@ variable "terraform_app_node_id" {
   default     = "A_kwHOBayTi84AAq0w"
 }
 
+variable "github_owner" {
+  description = "The namespace to be used to create repositories"
+  type        = string
+  default     = "Arrow-air"
+}
+
 variable "name" {
   description = "The repository name"
   type        = string

--- a/src/modules/github-repository/versions.tf
+++ b/src/modules/github-repository/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     github = {
       source  = "integrations/github"
-      version = "~> 4.0"
+      version = "~> 5.3"
     }
   }
 }

--- a/src/outputs.tf
+++ b/src/outputs.tf
@@ -1,3 +1,0 @@
-output "repositories" {
-  value = module.repository
-}

--- a/src/versions.tf
+++ b/src/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     github = {
       source  = "integrations/github"
-      version = "~> 4.0"
+      version = "~> 5.3"
     }
   }
 }


### PR DESCRIPTION
### DO NOT MERGE YET
This PR requires some manual state edits prior to merge to prevent these changes to be made:
```
  # module.repository_rust_lib["router"].github_branch.branch["develop"] will be destroyed
  # (because key ["develop"] is not in for_each map)
  - resource "github_branch" "branch" {
      - branch        = "develop" -> null
      - etag          = "W/\"afde9042310a362071d3e87e896e3c425c892bed00271b1f90657afeb6b85066\"" -> null
      - id            = "lib-router:develop" -> null
      - ref           = "refs/heads/develop" -> null
      - repository    = "lib-router" -> null
      - sha           = "c9c88ace24720ec6bc9391438a8c8b57eedba38b" -> null
      - source_branch = "main" -> null
      - source_sha    = "0e0c9c37b55e0eb9cad4fa5456134a58df941703" -> null
    }

  # module.repository_rust_lib["router"].github_branch.branch["main"] will be created
  + resource "github_branch" "branch" {
      + branch        = "main"
      + etag          = (known after apply)
      + id            = (known after apply)
      + ref           = (known after apply)
      + repository    = "lib-router"
      + sha           = (known after apply)
      + source_branch = "develop"
      + source_sha    = (known after apply)
    }
```

If a new repository is created from one of our templates, the default branch will be taken from that template repository which caused a conflict during the creation of all branches and branch protections.
This should fix these issues since we're now checking the default branch of the used template, and based on that, filter out the right branch for creation.

Als removed the outputs as they were only there for debugging purposes