### PR TITLE
fix: Add webflow to ignore paths, auto-create link checker and cspell config files

### DIFF
--- a/.cspell.config.yaml
+++ b/.cspell.config.yaml
@@ -19,3 +19,4 @@ ignorePaths:
   - '*.css'
   - '*.svg'
   - '*/**Makefile'
+  - '**webflow.js'

--- a/src/templates/all/.make/cspell.mk
+++ b/src/templates/all/.make/cspell.mk
@@ -1,6 +1,7 @@
 ## DO NOT EDIT!
 # This file was provisioned by Terraform
 # File origin: https://github.com/Arrow-air/tf-github/tree/main/src/templates/all/.make/cspell.mk
+CSPELL_PROJECT_WORDS ?= .cspell.project-words.txt
 
 .help-cspell:
 	@echo ""
@@ -12,6 +13,10 @@
 	@echo "                      to add remaining words to the project's cspell ignore list"
 
 cspell-test: docker-pull
+ifeq ("$(wildcard $(CSPELL_PROJECT_WORDS))","")
+	@echo "$(YELLOW)No $(CSPELL_PROJECT_WORDS) found, creating...$(SGR0)"
+	echo -e "\n" > $(CSPELL_PROJECT_WORDS)
+endif
 	@echo "$(CYAN)Checking for spelling errors...$(SGR0)"
 	@$(call docker_run,cspell --words-only --unique "**/**" -c .cspell.config.yaml)
 

--- a/src/templates/all/.make/cspell.mk
+++ b/src/templates/all/.make/cspell.mk
@@ -15,7 +15,7 @@ CSPELL_PROJECT_WORDS ?= .cspell.project-words.txt
 cspell-test: docker-pull
 ifeq ("$(wildcard $(CSPELL_PROJECT_WORDS))","")
 	@echo "$(YELLOW)No $(CSPELL_PROJECT_WORDS) found, creating...$(SGR0)"
-	echo -e "\n" > $(CSPELL_PROJECT_WORDS)
+	touch $(CSPELL_PROJECT_WORDS)
 endif
 	@echo "$(CYAN)Checking for spelling errors...$(SGR0)"
 	@$(call docker_run,cspell --words-only --unique "**/**" -c .cspell.config.yaml)

--- a/src/templates/all/.make/markdown.mk
+++ b/src/templates/all/.make/markdown.mk
@@ -3,6 +3,7 @@
 # File origin: https://github.com/Arrow-air/tf-github/tree/main/src/templates/all/.make/markdown.mk
 
 MARKDOWN_FILES ?= $(shell find . -type f -iname '*md' ! -iwholename "*./node_modules/*" ! -path "./build" ! -iwholename "*.terraform*" ! -iwholename "*.cargo/*")
+LINK_CHECKER_JSON ?= .link-checker.config.json
 
 .help-markdown:
 	@echo ""
@@ -10,6 +11,10 @@ MARKDOWN_FILES ?= $(shell find . -type f -iname '*md' ! -iwholename "*./node_mod
 	@echo "  $(BOLD)md-test-links$(SGR0)   -- Run markdown-link-check on all markdown files to catch dead links."
 
 md-test-links:
+ifeq ("$(wildcard $(LINK_CHECKER_JSON))","")
+	@echo "$(YELLOW)No $(LINK_CHECKER_JSON) found, creating...$(SGR0)"
+	echo -e "{\n}\n" > $(LINK_CHECKER_JSON)
+endif
 ifeq ("$(MARKDOWN_FILES)", "")
 	@echo "$(YELLOW)No markdown files found, skipping link validation...$(SGR0)"
 else
@@ -20,5 +25,6 @@ else
 		--user `id -u`:`id -g` \
 		-w "/usr/src/app" \
 		-v "$(PWD):/usr/src/app" \
-		-t ghcr.io/tcort/markdown-link-check:stable $(MARKDOWN_FILES)
+		-t ghcr.io/tcort/markdown-link-check:stable \
+		-c $(LINK_CHECKER_JSON) $(MARKDOWN_FILES)
 endif

--- a/src/templates/all/.make/markdown.mk
+++ b/src/templates/all/.make/markdown.mk
@@ -11,13 +11,13 @@ LINK_CHECKER_JSON ?= .link-checker.config.json
 	@echo "  $(BOLD)md-test-links$(SGR0)   -- Run markdown-link-check on all markdown files to catch dead links."
 
 md-test-links:
+ifeq ("$(MARKDOWN_FILES)", "")
+	@echo "$(YELLOW)No markdown files found, skipping link validation...$(SGR0)"
+else
 ifeq ("$(wildcard $(LINK_CHECKER_JSON))","")
 	@echo "$(YELLOW)No $(LINK_CHECKER_JSON) found, creating...$(SGR0)"
 	echo -e "{\n}\n" > $(LINK_CHECKER_JSON)
 endif
-ifeq ("$(MARKDOWN_FILES)", "")
-	@echo "$(YELLOW)No markdown files found, skipping link validation...$(SGR0)"
-else
 	@echo "$(CYAN)Checking if all document links are valid...$(SGR0)"
 	@docker run \
 		--name=$(DOCKER_NAME)-$@ \


### PR DESCRIPTION
link-checker config needed for website checks

ignore webflow.js in the website, wall of text

With this method we don't need to include .cspell.project-words.txt or .link-checker.config.json if they're unnecessary for the repo, they'll get auto-created in CI and allow things to run without erroring out due to lack of config