### PR TITLE
Multiple chore commits

### DIFF
--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -50,7 +50,7 @@ jobs:
         id: plan
         if: github.event_name == 'pull_request'
         run: |
-          terraform plan -no-color -lock=false -input=false -out tf.plan
+          terraform plan -no-color -lock=false -refresh=false -input=false -out tf.plan
         continue-on-error: true
 
       - name: Terraform Plan Show

--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -120,9 +120,9 @@ jobs:
         continue-on-error: true
 
       - name: Terraform Plan Status
-        if: steps.plan.outcome == 'failure'
+        if: steps.plan.outcome == 'failure' && !contains(github.event.head_commit.message, 'Provisioned by Terraform')
         run: exit 1
 
       - name: Terraform Apply
-        if: github.ref == 'refs/heads/main' && github.event_name == 'push'
+        if: github.ref == 'refs/heads/main' && github.event_name == 'push' && !contains(github.event.head_commit.message, 'Provisioned by Terraform')
         run: terraform apply -auto-approve -input=false

--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -22,6 +22,8 @@ jobs:
     defaults:
       run:
         working-directory: src
+    concurrency:
+      group: terraform-${{ github.head_ref || 'main' }}
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -48,7 +50,7 @@ jobs:
         id: plan
         if: github.event_name == 'pull_request'
         run: |
-          terraform plan -no-color -input=false -out tf.plan
+          terraform plan -no-color -lock=false -input=false -out tf.plan
         continue-on-error: true
 
       - name: Terraform Plan Show

--- a/src/modules/github-repository/main.tf
+++ b/src/modules/github-repository/main.tf
@@ -139,7 +139,7 @@ resource "github_branch_protection" "all" {
   pattern                = each.key
   enforce_admins         = true
   allows_deletions       = true
-  require_signed_commits = true
+  require_signed_commits = false # We need to figure out how to ignore the Terraform commits for this to be set to true
   allows_force_pushes    = true
 
   depends_on = [

--- a/src/repositories_rust.tf
+++ b/src/repositories_rust.tf
@@ -20,7 +20,16 @@ locals {
 
   rust_svc = {
     template_files = local.rust_default.template_files
-    files          = local.rust_default.files
+    files = merge(
+      local.rust_default.files, {
+        "Dockerfile" = {
+          content = file("templates/rust-all/Dockerfile")
+        },
+        ".github/workflows/sanity_checks.yml" = {
+          content = file("templates/rust-all/.github/workflows/sanity_checks.yml")
+        }
+      }
+    )
 
     repos = {
       "storage" = {


### PR DESCRIPTION
Make sure the Dockerfile is deployed to al svc-* repositories
Only allow 1 terraform apply run at a time
Remove state locking on terraform plan actions
Remove require_signed_commits again for personal branches