### PR TITLE
fix(docker): build package name was not provided properly

### DIFF
--- a/src/templates/all/.make/docker.mk
+++ b/src/templates/all/.make/docker.mk
@@ -13,7 +13,7 @@ IMAGE_NAME        ?= $(PACKAGE_NAME)
 	@echo "  $(BOLD)docker-stop$(SGR0) -- Run 'docker kill $${DOCKER_NAME}-run' to stop our docker after running"
 
 docker-build:
-	@DOCKER_BUILDKIT=1 docker build --build-arg PACKAGE_NAME --tag $(IMAGE_NAME):latest $(DOCKER_BUILD_PATH)
+	@DOCKER_BUILDKIT=1 docker build --build-arg PACKAGE_NAME=$(PACKAGE_NAME) --tag $(IMAGE_NAME):latest $(DOCKER_BUILD_PATH)
 
 docker-run: docker-stop
 	# Run docker container as a daemon and map a port

--- a/src/templates/rust-all/Makefile.tftpl
+++ b/src/templates/rust-all/Makefile.tftpl
@@ -12,7 +12,7 @@ build: rust-build
 %{ else }
 IMAGE_NAME   := ${name}
 PACKAGE_NAME := $(IMAGE_NAME)
-DOCKER_PORT  := 8080
+DOCKER_PORT  := 8000
 HOST_PORT    := ${port}
 
 help: .help-base .help-rust .help-python .help-cspell .help-markdown .help-editorconfig .help-toml .help-docker


### PR DESCRIPTION
The docker build-arg did not have the `PACKAGE_NAME` set properly.
Also fixed the `DOCKER_PORT` which is set to 8000 in the rust server.