### PR TITLE
add make editorconfig-tidy and format-all targets

### DIFF
--- a/src/templates/all/.make/editorconfig.mk
+++ b/src/templates/all/.make/editorconfig.mk
@@ -6,6 +6,7 @@
 	@echo ""
 	@echo "$(SMUL)$(BOLD)$(GREEN)Editorconfig$(SGR0)"
 	@echo "  $(BOLD)editorconfig-test$(SGR0) -- Run editorconfig test to validate all file formats are valid"
+	@echo "  $(BOLD)editorconfig-tidy$(SGR0) -- Run editorconfig tidy to fix all file formats if needed"
 
 editorconfig-test:
 	@echo "$(CYAN)Checking if the codebase is compliant with the .editorconfig file...$(SGR0)"
@@ -16,3 +17,7 @@ editorconfig-test:
 		-w "/usr/src/app" \
 		-v "$(PWD):/usr/src/app" \
 		-t mstruebing/editorconfig-checker
+
+editorconfig-tidy: docker-pull
+	@echo "$(CYAN)Running editorconfig formatting fixes...$(SGR0)"
+	@$(call docker_run,sh -c 'eclint fix .')

--- a/src/templates/rust-all/Makefile.tftpl
+++ b/src/templates/rust-all/Makefile.tftpl
@@ -23,7 +23,7 @@ include .make/docker.mk
 %{ endif }
 release: rust-release
 test: rust-test-all cspell-test toml-test python-test md-test-links editorconfig-test
-tidy: rust-tidy toml-tidy python-tidy
+tidy: rust-tidy toml-tidy python-tidy editorconfig-tidy
 
 include .make/base.mk
 include .make/cspell.mk


### PR DESCRIPTION
This adds `editorconfig-tidy` - uses eclint under the hood to fix common issues like whitespaces
Updates `tidy` to include `editorconfig-tidy` to format files in one command