### PR TITLE
feat(examples): use docker compose to run examples

### DIFF
--- a/.cspell.project-words.txt
+++ b/.cspell.project-words.txt
@@ -23,3 +23,4 @@ toset
 tput
 webdevelopers
 yapf
+healthcheck

--- a/src/repositories_rust.tf
+++ b/src/repositories_rust.tf
@@ -23,7 +23,10 @@ locals {
     files = merge(
       local.rust_default.files, {
         "Dockerfile" = {
-          content = file("templates/rust-all/Dockerfile")
+          content = file("templates/rust-svc/Dockerfile")
+        },
+        "docker-compose.yml" = {
+          content = file("templates/rust-svc/docker-compose.yml")
         },
         ".github/workflows/sanity_checks.yml" = {
           content = file("templates/rust-all/.github/workflows/sanity_checks.yml")

--- a/src/templates/rust-svc/Dockerfile
+++ b/src/templates/rust-svc/Dockerfile
@@ -1,7 +1,7 @@
 ## DO NOT EDIT!
 # This file was provisioned by Terraform
 # File origin: https://github.com/Arrow-air/tf-github/tree/main/src/templates/rust-all/Dockerfile
-FROM ghcr.io/arrow-air/tools/arrow-rust:latest AS build
+FROM --platform=$BUILDPLATFORM ghcr.io/arrow-air/tools/arrow-rust:latest AS build
 
 ENV CARGO_INCREMENTAL=1
 ENV RUSTC_BOOTSTRAP=0
@@ -10,7 +10,7 @@ COPY . /usr/src/app
 
 RUN cd /usr/src/app ; cargo build --release
 
-FROM alpine:latest
+FROM --platform=$TARGETPLATFORM alpine:latest
 ARG PACKAGE_NAME=
 COPY --from=build /usr/src/app/target/release/${PACKAGE_NAME} /usr/local/bin/${PACKAGE_NAME}
 RUN ln -s /usr/local/bin/${PACKAGE_NAME} /usr/local/bin/server

--- a/src/templates/rust-svc/docker-compose.yml
+++ b/src/templates/rust-svc/docker-compose.yml
@@ -1,0 +1,34 @@
+---
+version: '3.6'
+services:
+  web-server:
+    container_name: ${PACKAGE_NAME}-run
+    image: ${IMAGE_NAME}:latest
+    ports:
+      - ${HOST_PORT}:${DOCKER_PORT}
+    healthcheck:
+      test: ["CMD", "wget", "--spider", "--no-verbose", "--tries=1", "http://localhost:${DOCKER_PORT}/live"]
+      interval: 2s
+      timeout: 1s
+      retries: 3
+
+  example:
+    links:
+      - web-server
+    depends_on:
+      web-server:
+        condition: service_healthy
+    container_name: ${PACKAGE_NAME}-example
+    image: ${BUILD_IMAGE_NAME}:${BUILD_IMAGE_TAG}
+    volumes:
+      - type: bind
+        source: "${SOURCE_PATH}/"
+        target: "/usr/src/app"
+      - type: bind
+        source: "${SOURCE_PATH}/.cargo/registry"
+        target: "/usr/local/cargo/registry"
+    environment:
+      - HOSTNAME
+      - DOCKER_PORT
+      - EXAMPLE_TARGET
+    command: cargo run --manifest-path "${CARGO_MANIFEST_PATH}" --example "${EXAMPLE_TARGET}"


### PR DESCRIPTION
Creating a `rust-svc` specific templates directory again for files only needed for our svc repositories.
Adding a docker-compose configuration file to make sure the server is running when calling the cargo example target.
Providing a specific cargo-run function and separating the docker commands for rust completely.