### PR TITLE
feat(sanity checks): add check for commit messages

### DIFF
--- a/.cspell.project-words.txt
+++ b/.cspell.project-words.txt
@@ -23,4 +23,6 @@ toset
 tput
 webdevelopers
 yapf
+commitlint
+commitlintrc
 healthcheck

--- a/src/main.tf
+++ b/src/main.tf
@@ -26,6 +26,9 @@ locals {
     ".editorconfig" = {
       content = file("templates/all/.editorconfig")
     },
+    ".commitlintrc.yml" = {
+      content = file("templates/all/.commitlintrc.yml")
+    },
     ".cspell.config.yaml" = {
       content = file("templates/all/.cspell.config.yaml")
     },
@@ -34,6 +37,9 @@ locals {
     },
     ".make/cspell.mk" = {
       content = file("templates/all/.make/cspell.mk")
+    },
+    ".make/commitlint.mk" = {
+      content = file("templates/all/.make/commitlint.mk")
     },
     ".make/editorconfig.mk" = {
       content = file("templates/all/.make/editorconfig.mk")

--- a/src/repositories_rust.tf
+++ b/src/repositories_rust.tf
@@ -81,6 +81,9 @@ locals {
       ".cargo-husky/hooks/pre-push" = {
         content = file("templates/rust-all/.cargo-husky/hooks/pre-push")
       },
+      ".cargo-husky/hooks/commit-msg" = {
+        content = file("templates/rust-all/.cargo-husky/hooks/commit-msg")
+      },
       ".cargo-husky/hooks/README.md" = {
         content = file("templates/rust-all/.cargo-husky/hooks/README.md")
       },

--- a/src/templates/all/.commitlintrc.yml
+++ b/src/templates/all/.commitlintrc.yml
@@ -1,0 +1,18 @@
+rules:
+  body-leading-blank: [1, always]
+  body-max-line-length: [2, always, 100]
+  footer-leading-blank: [1, always]
+  footer-max-line-length: [2, always, 100]
+  header-max-length: [2, always, 100]
+  subject-case:
+    - 2
+    - never
+    - [sentence-case, start-case, pascal-case, upper-case]
+  subject-empty: [2, never]
+  subject-full-stop: [2, never, "."]
+  type-case: [2, always, lower-case]
+  type-empty: [2, never]
+  type-enum:
+    - 2
+    - always
+    - [build, chore, ci, docs, feat, fix, perf, refactor, revert, style, test]

--- a/src/templates/all/.make/base.mk
+++ b/src/templates/all/.make/base.mk
@@ -4,8 +4,9 @@
 
 SHELL := /bin/bash
 
-BUILD_IMAGE_NAME := ghcr.io/arrow-air/tools/arrow-rust
-BUILD_IMAGE_TAG  := latest
+SANITYCHECKS_IMAGE_NAME := ghcr.io/arrow-air/tools/arrow-sanitychecks
+SANITYCHEKCS_IMAGE_TAG  := 0.1
+
 SOURCE_PATH      ?= $(PWD)
 
 # Style templates for console output.
@@ -21,19 +22,18 @@ SGR0   := $(shell echo -e `tput sgr0`)
 docker_run = docker run \
 	--name=$(DOCKER_NAME)-$@ \
 	--rm \
-	-e HOST_PORT=$(HOST_PORT) \
 	--user `id -u`:`id -g` \
 	--workdir=/usr/src/app \
 	-v "$(SOURCE_PATH)/:/usr/src/app" \
 	$(2) \
-	-t $(BUILD_IMAGE_NAME):$(BUILD_IMAGE_TAG) \
+	-t $(SANITYCHECKS_IMAGE_NAME):$(SANITYCHEKCS_IMAGE_TAG) \
 	$(1)
 
-.SILENT: docker-pull
+.SILENT: *docker-pull
 
 .help-base:
 	@echo ""
 	@echo "$(BOLD)$(CYAN)Available targets$(SGR0)"
 
 docker-pull:
-	@docker pull -q $(BUILD_IMAGE_NAME):$(BUILD_IMAGE_TAG)
+	@echo docker pull -q $(SANITYCHECKS_IMAGE_NAME):$(SANITYCHEKCS_IMAGE_TAG)

--- a/src/templates/all/.make/commitlint.mk
+++ b/src/templates/all/.make/commitlint.mk
@@ -1,0 +1,15 @@
+## DO NOT EDIT!
+# This file was provisioned by Terraform
+# File origin: https://github.com/Arrow-air/tf-github/tree/main/src/templates/all/.make/commitlint.mk
+
+COMMITLINT_CHECK :=
+
+.help-commitlint:
+	@echo ""
+	@echo "$(SMUL)$(BOLD)$(GREEN)Commitlint$(SGR0)"
+	@echo "  $(BOLD)commitlint-test$(SGR0)  -- Run 'commitlint --edit $(COMMITLINT_CHECK)'"
+	@echo "                      to validate commit messages are following the conventional commit standards."
+
+commitlint-test: docker-pull
+	@echo "$(CYAN)Checking for commit message errors...$(SGR0)"
+	@$(call docker_run,commitlint --edit $(COMMITLINT_CHECK))

--- a/src/templates/rust-all/.cargo-husky/hooks/commit-msg
+++ b/src/templates/rust-all/.cargo-husky/hooks/commit-msg
@@ -1,0 +1,2 @@
+export COMMITLINT_CHECK=${1}
+make commitlint-test

--- a/src/templates/rust-all/.github/workflows/rust_ci.yml
+++ b/src/templates/rust-all/.github/workflows/rust_ci.yml
@@ -1,8 +1,7 @@
 ## DO NOT EDIT!
 # This file was provisioned by Terraform
-# Check file validity at: https://rhysd.github.io/actionlint/
-# https://github.com/actions/virtual-environments/blob/main/images/linux/Ubuntu2004-Readme.md
-
+# File origin: https://github.com/Arrow-air/tf-github/tree/main/src/templates/rust-all/.github/workflows/rust_ci.yml
+#
 on:
   push:
     branches:
@@ -18,6 +17,7 @@ jobs:
   check:
     name: Checks
     runs-on: ubuntu-latest
+    if: ${{ !contains(github.event.head_commit.message, 'provisioned by terraform') }}
     steps:
       - uses: actions/checkout@v2
       - run: make rust-check
@@ -25,13 +25,13 @@ jobs:
   build_and_test_debug:
     name: Build & Test
     runs-on: ubuntu-latest
+    if: ${{ !contains(github.event.head_commit.message, 'provisioned by terraform') }}
     steps:
       - uses: actions/checkout@v2
       - name: Build
         run: make build
       - name: Test
         run: make rust-test
-      # Coming soon: grcov + push results to website or service (coveralls, etc.)
 
   fmt:
     name: Rustfmt

--- a/src/templates/rust-all/.github/workflows/sanity_checks.yml
+++ b/src/templates/rust-all/.github/workflows/sanity_checks.yml
@@ -8,9 +8,6 @@ env:
   TERM: xterm
 
 on:
-  push:
-    branches:
-      - main
   pull_request:
 
 jobs:
@@ -41,3 +38,42 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - run: make toml-test
+
+  commit-msg:
+    name: Commit message Check
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - run: npx commitlint --from=${{ github.event.pull_request.base.sha }}
+
+  release-notes:
+    name: Preview Release Notes
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - name: Generate Changelog
+        id: changelog
+        uses: mrchief/universal-changelog-action@v1.3.1
+        with:
+          previousReleaseTagNameOrSha: ${{ github.event.pull_request.base.sha }}
+          nextReleaseTagName: ${{ github.sha }}
+          nextReleaseName: "Release ${{ steps.tag_version.outputs.new_version }}"
+
+      - name: Add PR Comment with Changelog Output
+        uses: thollander/actions-comment-pull-request@v1
+        continue-on-error: true
+        with:
+          message: |
+            <details>
+            <summary>This PR will generate the following release notes when merged:</summary>
+
+            ${{ steps.changelog.outputs.changelog }}
+
+            </details>
+          comment_includes: 'This PR will generate the following release notes when merged'

--- a/src/templates/rust-all/Makefile.tftpl
+++ b/src/templates/rust-all/Makefile.tftpl
@@ -15,7 +15,7 @@ PACKAGE_NAME := $(IMAGE_NAME)
 DOCKER_PORT  := 8000
 HOST_PORT    := ${port}
 
-help: .help-base .help-rust .help-python .help-cspell .help-markdown .help-editorconfig .help-toml .help-docker
+help: .help-base .help-rust .help-python .help-cspell .help-markdown .help-editorconfig .help-commitlint .help-toml .help-docker
 build: rust-build docker-build
 all: test build release
 
@@ -29,6 +29,7 @@ include .make/base.mk
 include .make/cspell.mk
 include .make/markdown.mk
 include .make/editorconfig.mk
+include .make/commitlint.mk
 include .make/toml.mk
 include .make/rust.mk
 include .make/python.mk


### PR DESCRIPTION
In preparation for automatic release and changelog generation, I've added commitlint to the workflows so we can start writing proper commit messages for changelog tracking.
In addition, a comment will be added to each PR showing a preview for the Changelog output.