### PR TITLE
feat(rust-svc): release workflow

### DIFF
--- a/src/main.tf
+++ b/src/main.tf
@@ -134,7 +134,8 @@ locals {
               owner_team = "services"
               type       = "svc"
               name       = "tool-simulation"
-              port       = 3000
+              port_rest  = 3000
+              port_grpc  = ""
             })
           }
         }

--- a/src/repositories_rust.tf
+++ b/src/repositories_rust.tf
@@ -129,7 +129,8 @@ module "repository_rust_lib" {
           owner_team = each.value.owner_team
           type       = "lib"
           name       = format("lib-%s", each.key)
-          port       = ""
+          port_rest  = ""
+          port_grpc  = ""
         })
       }
     }
@@ -162,7 +163,8 @@ module "repository_rust_svc" {
           owner_team = each.value.owner_team
           type       = "svc"
           name       = format("svc-%s", each.key)
-          port       = format("80%02.0f", index(keys(local.rust_svc.repos), each.key))
+          port_rest  = format("80%02.0f", index(keys(local.rust_svc.repos), each.key))
+          port_grpc  = format("500%02.0f", index(keys(local.rust_svc.repos), each.key))
         })
       }
     }

--- a/src/repositories_templates.tf
+++ b/src/repositories_templates.tf
@@ -70,7 +70,8 @@ module "repository_lib_template" {
         owner_team = each.value.owner_team
         type       = "lib"
         name       = format("lib-template-%s", each.key)
-        port       = ""
+        port_rest  = ""
+        port_grpc  = ""
         }
     ) } }
   )
@@ -102,7 +103,8 @@ module "repository_svc_template" {
         owner_team = each.value.owner_team
         type       = "svc"
         name       = format("svc-template-%s", each.key)
-        port       = 8080 # arbitrary, template files not used in prod
+        port_rest  = 8080  # arbitrary, template files not used in prod
+        port_grpc  = 50051 # arbitrary, template files not used in prod
         }
     ) } }
   )

--- a/src/templates/all/.make/base.mk
+++ b/src/templates/all/.make/base.mk
@@ -5,7 +5,7 @@
 SHELL := /bin/bash
 
 SANITYCHECKS_IMAGE_NAME := ghcr.io/arrow-air/tools/arrow-sanitychecks
-SANITYCHEKCS_IMAGE_TAG  := 0.1
+SANITYCHECKS_IMAGE_TAG  := 0.1
 
 SOURCE_PATH      ?= $(PWD)
 
@@ -26,7 +26,7 @@ docker_run = docker run \
 	--workdir=/usr/src/app \
 	-v "$(SOURCE_PATH)/:/usr/src/app" \
 	$(2) \
-	-t $(SANITYCHECKS_IMAGE_NAME):$(SANITYCHEKCS_IMAGE_TAG) \
+	-t $(SANITYCHECKS_IMAGE_NAME):$(SANITYCHECKS_IMAGE_TAG) \
 	$(1)
 
 .SILENT: *docker-pull
@@ -36,4 +36,4 @@ docker_run = docker run \
 	@echo "$(BOLD)$(CYAN)Available targets$(SGR0)"
 
 docker-pull:
-	@echo docker pull -q $(SANITYCHECKS_IMAGE_NAME):$(SANITYCHEKCS_IMAGE_TAG)
+	@echo docker pull -q $(SANITYCHECKS_IMAGE_NAME):$(SANITYCHECKS_IMAGE_TAG)

--- a/src/templates/all/.make/docker.mk
+++ b/src/templates/all/.make/docker.mk
@@ -8,9 +8,9 @@ IMAGE_NAME        ?= $(PACKAGE_NAME)
 .help-docker:
 	@echo ""
 	@echo "$(SMUL)$(BOLD)$(GREEN)Docker targets$(SGR0)"
-	@echo "  $(BOLD)docker-build$(SGR0)-- Run docker build to create new image"
-	@echo "  $(BOLD)docker-run$(SGR0)  -- Run docker container as a daemon, binding port $(HOST_PORT):$(DOCKER_PORT)"
-	@echo "  $(BOLD)docker-stop$(SGR0) -- Run 'docker kill $${DOCKER_NAME}-run' to stop our docker after running"
+	@echo "  $(BOLD)docker-build$(SGR0)  -- Run docker build to create new image"
+	@echo "  $(BOLD)docker-run$(SGR0)    -- Run docker container as a daemon, binding port $(HOST_PORT):$(DOCKER_PORT)"
+	@echo "  $(BOLD)docker-stop$(SGR0)   -- Run 'docker kill $${DOCKER_NAME}-run' to stop our docker after running"
 
 docker-build:
 	@DOCKER_BUILDKIT=1 docker build --build-arg PACKAGE_NAME=$(PACKAGE_NAME) --tag $(IMAGE_NAME):latest $(DOCKER_BUILD_PATH)

--- a/src/templates/all/.make/docker.mk
+++ b/src/templates/all/.make/docker.mk
@@ -8,17 +8,17 @@ IMAGE_NAME        ?= $(PACKAGE_NAME)
 .help-docker:
 	@echo ""
 	@echo "$(SMUL)$(BOLD)$(GREEN)Docker targets$(SGR0)"
-	@echo "  $(BOLD)docker-build$(SGR0)  -- Run docker build to create new image"
-	@echo "  $(BOLD)docker-run$(SGR0)    -- Run docker container as a daemon, binding port $(HOST_PORT):$(DOCKER_PORT)"
-	@echo "  $(BOLD)docker-stop$(SGR0)   -- Run 'docker kill $${DOCKER_NAME}-run' to stop our docker after running"
+	@echo "  $(BOLD)docker-build$(SGR0)   -- Run docker build to create new image"
+	@echo "  $(BOLD)docker-run$(SGR0)     -- Run docker container as a daemon, binding port $(HOST_PORT):$(DOCKER_PORT)"
+	@echo "  $(BOLD)docker-stop$(SGR0)    -- Run 'docker kill $${DOCKER_NAME}-run' to stop our docker after running"
 
 docker-build:
 	@DOCKER_BUILDKIT=1 docker build --build-arg PACKAGE_NAME=$(PACKAGE_NAME) --tag $(IMAGE_NAME):latest $(DOCKER_BUILD_PATH)
 
 docker-run: docker-stop
 	# Run docker container as a daemon and map a port
-	@docker run --rm -d -p $(HOST_PORT):$(DOCKER_PORT) --name=$(DOCKER_NAME)-run $(IMAGE_NAME):latest
-	@echo "$(YELLOW)Docker running and listening to http://localhost:$(HOST_PORT)$(SGR0)"
+	@docker run --rm -d -p $(HOST_PORT_GRPC):$(DOCKER_PORT_GRPC) -p $(HOST_PORT_REST):$(DOCKER_PORT_REST) --name=$(DOCKER_NAME)-run $(IMAGE_NAME):latest
+	@echo "$(YELLOW)Docker running and listening to http://localhost:$(HOST_PORT_GRPC) and http://localhost:$(HOST_PORT_REST) $(SGR0)"
 
 docker-stop:
 	@docker kill ${DOCKER_NAME}-run || true

--- a/src/templates/all/.make/docker.mk
+++ b/src/templates/all/.make/docker.mk
@@ -3,7 +3,6 @@
 # File origin: https://github.com/Arrow-air/tf-github/tree/main/src/templates/all/.make/docker.mk
 
 DOCKER_BUILD_PATH ?= .
-IMAGE_NAME        ?= $(PACKAGE_NAME)
 
 .help-docker:
 	@echo ""
@@ -13,11 +12,11 @@ IMAGE_NAME        ?= $(PACKAGE_NAME)
 	@echo "  $(BOLD)docker-stop$(SGR0)    -- Run 'docker kill $${DOCKER_NAME}-run' to stop our docker after running"
 
 docker-build:
-	@DOCKER_BUILDKIT=1 docker build --build-arg PACKAGE_NAME=$(PACKAGE_NAME) --tag $(IMAGE_NAME):latest $(DOCKER_BUILD_PATH)
+	@DOCKER_BUILDKIT=1 docker build --build-arg PACKAGE_NAME=$(PACKAGE_NAME) --tag $(PACKAGE_NAME):latest $(DOCKER_BUILD_PATH)
 
 docker-run: docker-stop
 	# Run docker container as a daemon and map a port
-	@docker run --rm -d -p $(HOST_PORT_GRPC):$(DOCKER_PORT_GRPC) -p $(HOST_PORT_REST):$(DOCKER_PORT_REST) --name=$(DOCKER_NAME)-run $(IMAGE_NAME):latest
+	@docker run --rm -d -p $(HOST_PORT_GRPC):$(DOCKER_PORT_GRPC) -p $(HOST_PORT_REST):$(DOCKER_PORT_REST) --name=$(DOCKER_NAME)-run $(PACKAGE_NAME):latest
 	@echo "$(YELLOW)Docker running and listening to http://localhost:$(HOST_PORT_GRPC) and http://localhost:$(HOST_PORT_REST) $(SGR0)"
 
 docker-stop:

--- a/src/templates/all/.make/rust.mk
+++ b/src/templates/all/.make/rust.mk
@@ -9,6 +9,7 @@ CARGO_INCREMENTAL   ?= 1
 RUSTC_BOOTSTRAP     ?= 0
 RELEASE_TARGET      ?= x86_64-unknown-linux-musl
 HOSTNAME            ?= $(DOCKER_NAME)-run
+PUBLISH_DRY_RUN     ?= 1
 
 # function with a generic template to run docker with the required values
 # Accepts $1 = command to run, $2 = additional command flags (optional)
@@ -38,6 +39,8 @@ rust-docker-pull:
 	@echo "  $(BOLD)rust-build$(SGR0)       -- Run 'cargo build'"
 	@echo "  $(BOLD)rust-release$(SGR0)     -- Run 'cargo build --release --target RELEASE_TARGET'"
 	@echo "                     (RELEASE_TARGET=$(RELEASE_TARGET))"
+	@echo "  $(BOLD)rust-publish$(SGR0)     -- Run 'cargo publish --package $(PACKAGE_NAME)-client-grpc'"
+	@echo "                     uses '--dry-run' by default, automation uses PUBLISH_DRY_RUN=0 to upload crate"
 	@echo "  $(BOLD)rust-clean$(SGR0)       -- Run 'cargo clean'"
 	@echo "  $(BOLD)rust-check$(SGR0)       -- Run 'cargo check'"
 	@echo "  $(BOLD)rust-test$(SGR0)        -- Run 'cargo test --all'"
@@ -62,6 +65,14 @@ rust-build: check-cargo-registry rust-docker-pull
 rust-release: check-cargo-registry rust-docker-pull
 	@echo "$(CYAN)Running cargo build --release...$(SGR0)"
 	@$(call cargo_run,build,--release --target $(RELEASE_TARGET))
+
+rust-publish: check-cargo-registry rust-docker-pull
+	@echo "$(CYAN)Running cargo publish --package $(PACKAGE_NAME)-client-grpc...$(SGR0)"
+ifeq ("$(PUBLISH_DRY_RUN)", "0")
+	@echo $(call cargo_run,publish,--package $(PACKAGE_NAME)-client-grpc --target $(RELEASE_TARGET))
+else
+	@$(call cargo_run,publish,--dry-run --package $(PACKAGE_NAME)-client-grpc --target $(RELEASE_TARGET))
+endif
 
 rust-clean: check-cargo-registry rust-docker-pull
 	@echo "$(CYAN)Running cargo clean...$(SGR0)"

--- a/src/templates/all/.make/rust.mk
+++ b/src/templates/all/.make/rust.mk
@@ -39,7 +39,7 @@ rust-docker-pull:
 	@echo "  $(BOLD)rust-build$(SGR0)       -- Run 'cargo build'"
 	@echo "  $(BOLD)rust-release$(SGR0)     -- Run 'cargo build --release --target RELEASE_TARGET'"
 	@echo "                     (RELEASE_TARGET=$(RELEASE_TARGET))"
-	@echo "  $(BOLD)rust-publish$(SGR0)     -- Run 'cargo publish --package $(PACKAGE_NAME)-client-grpc'"
+	@echo "  $(BOLD)rust-publish$(SGR0)     -- Run 'cargo publish --package $(PUBLISH_PACKAGE_NAME)'"
 	@echo "                     uses '--dry-run' by default, automation uses PUBLISH_DRY_RUN=0 to upload crate"
 	@echo "  $(BOLD)rust-clean$(SGR0)       -- Run 'cargo clean'"
 	@echo "  $(BOLD)rust-check$(SGR0)       -- Run 'cargo check'"
@@ -67,11 +67,11 @@ rust-release: check-cargo-registry rust-docker-pull
 	@$(call cargo_run,build,--release --target $(RELEASE_TARGET))
 
 rust-publish: check-cargo-registry rust-docker-pull
-	@echo "$(CYAN)Running cargo publish --package $(PACKAGE_NAME)-client-grpc...$(SGR0)"
+	@echo "$(CYAN)Running cargo publish --package $(PUBLISH_PACKAGE_NAME)...$(SGR0)"
 ifeq ("$(PUBLISH_DRY_RUN)", "0")
-	@echo $(call cargo_run,publish,--package $(PACKAGE_NAME)-client-grpc --target $(RELEASE_TARGET))
+	@echo $(call cargo_run,publish,--package $(PUBLISH_PACKAGE_NAME) --target $(RELEASE_TARGET))
 else
-	@$(call cargo_run,publish,--dry-run --package $(PACKAGE_NAME)-client-grpc --target $(RELEASE_TARGET))
+	@$(call cargo_run,publish,--dry-run --package $(PUBLISH_PACKAGE_NAME) --target $(RELEASE_TARGET))
 endif
 
 rust-clean: check-cargo-registry rust-docker-pull
@@ -94,6 +94,8 @@ rust-example-%: check-cargo-registry rust-docker-pull
 		-e CARGO_INCREMENTAL=1 \
 		-e RUSTC_BOOTSTRAP=0 \
 		-e EXAMPLE_TARGET=$(EXAMPLE_TARGET) \
+		-e SERVER_PORT_GRPC=$(DOCKER_PORT_GRPC) \
+		-e SERVER_PORT_REST=$(DOCKER_PORT_REST) \
 		example && docker compose stop
 
 rust-clippy: check-cargo-registry rust-docker-pull

--- a/src/templates/all/.make/toml.mk
+++ b/src/templates/all/.make/toml.mk
@@ -2,7 +2,7 @@
 # This file was provisioned by Terraform
 # File origin: https://github.com/Arrow-air/tf-github/tree/main/src/templates/all/.make/toml.mk
 
-TOML_FILES ?= $(shell find . -type f -iname '*.toml')
+TOML_FILES ?= $(shell find . -type f -iname '*.toml' ! -path "./target")
 
 .help-toml:
 	@echo ""

--- a/src/templates/benchmarks/Makefile
+++ b/src/templates/benchmarks/Makefile
@@ -26,7 +26,7 @@ docker_run = docker run \
 	--user `id -u`:`id -g` \
 	-v "$(PWD):/usr/src/app" \
 	$(2) \
-	-t $(BUILD_IMAGE_NAME):$(BUILD_IMAGE_TAG) \
+	-t $(RUST_IMAGE_NAME):$(RUST_IMAGE_TAG) \
 	$(1)
 
 SOURCE_PATH=$(PWD)/server-web

--- a/src/templates/rust-all/.taplo.toml
+++ b/src/templates/rust-all/.taplo.toml
@@ -1,7 +1,7 @@
 ## DO NOT EDIT!
 # This file was provisioned by Terraform
 # File origin: https://github.com/Arrow-air/tf-github/tree/main/src/templates/rust-all/.taplo.toml
-exclude = ["**/.cargo/registry/**"]
+exclude = ["**/.cargo/registry/**", "target/**"]
 
 [formatting]
 align_entries = true

--- a/src/templates/rust-all/Makefile.tftpl
+++ b/src/templates/rust-all/Makefile.tftpl
@@ -9,6 +9,7 @@ DOCKER_NAME := arrow-${name}
 help: .help-base .help-rust .help-python .help-cspell .help-markdown .help-editorconfig .help-toml
 all: test build release rust-publish
 build: rust-build
+publish: rust-publish
 %{ else }
 IMAGE_NAME   := ${name}
 PACKAGE_NAME := $(IMAGE_NAME)

--- a/src/templates/rust-all/Makefile.tftpl
+++ b/src/templates/rust-all/Makefile.tftpl
@@ -10,7 +10,6 @@ PUBLISH_PACKAGE_NAME := $(name)
 help: .help-base .help-rust .help-python .help-cspell .help-markdown .help-editorconfig .help-commitlint .help-toml
 build: rust-build
 %{ else }
-IMAGE_NAME           := ${name}
 PUBLISH_PACKAGE_NAME := $(name)-client-grpc
 DOCKER_PORT_REST     := 8000
 DOCKER_PORT_GRPC     := 50051

--- a/src/templates/rust-all/Makefile.tftpl
+++ b/src/templates/rust-all/Makefile.tftpl
@@ -2,29 +2,34 @@
 # This file was provisioned by Terraform
 # File origin: https://github.com/Arrow-air/tf-github/tree/main/src/templates/rust-all/Makefile.tftpl
 
-DOCKER_NAME := arrow-${name}
-
-# Combined targets
+DOCKER_NAME          := arrow-${name}
+PACKAGE_NAME         := $(name)
 %{ if type == "lib" }
-help: .help-base .help-rust .help-python .help-cspell .help-markdown .help-editorconfig .help-toml
-all: test build release rust-publish
+PUBLISH_PACKAGE_NAME := $(name)
+
+help: .help-base .help-rust .help-python .help-cspell .help-markdown .help-editorconfig .help-commitlint .help-toml
 build: rust-build
-publish: rust-publish
 %{ else }
-IMAGE_NAME   := ${name}
-PACKAGE_NAME := $(IMAGE_NAME)
-DOCKER_PORT  := 8000
-HOST_PORT    := ${port}
+IMAGE_NAME           := ${name}
+PUBLISH_PACKAGE_NAME := $(name)-client-grpc
+DOCKER_PORT_REST     := 8000
+DOCKER_PORT_GRPC     := 50051
+HOST_PORT_REST       := ${port_rest}
+HOST_PORT_GRPC       := ${port_grpc}
 
 help: .help-base .help-rust .help-python .help-cspell .help-markdown .help-editorconfig .help-commitlint .help-toml .help-docker
 build: rust-build docker-build
-all: test build release
 
 include .make/docker.mk
 %{ endif }
+export
+
+clean: rust-clean
 release: rust-release
+publish: rust-publish
 test: rust-test-all cspell-test toml-test python-test md-test-links editorconfig-test
 tidy: rust-tidy toml-tidy python-tidy editorconfig-tidy
+all: clean test build release publish
 
 include .make/base.mk
 include .make/cspell.mk

--- a/src/templates/rust-svc/.github/workflows/release.yml
+++ b/src/templates/rust-svc/.github/workflows/release.yml
@@ -1,0 +1,177 @@
+## DO NOT EDIT!
+# This file was provisioned by Terraform
+# File origin: https://github.com/Arrow-air/tf-github/tree/main/src/templates/rust-svc/.github/workflows/release.yml
+
+name: Tag and Release
+
+on:
+  push:
+    branches:
+      - 'main'
+      - 'develop'
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+  TERM: xterm
+
+jobs:
+  prepare:
+    name: Create Tag and Release notes
+    if: ${{ !contains(github.event.head_commit.message, 'Provisioned by Terraform') }}
+    permissions:
+      contents: write
+      packages: write
+      deployments: write
+    runs-on: ubuntu-latest
+    concurrency:
+      group: release-${{ github.head_ref || 'main' }}
+    steps:
+      - id: generate-token
+        uses: tibdex/github-app-token@v1
+        with:
+          app_id: ${{ secrets.RELEASE_AUTOMATION_APP_ID }}
+          private_key: ${{ secrets.RELEASE_AUTOMATION_PRIVATE_KEY }}
+      - name: Checkout Code
+        uses: actions/checkout@v3
+        with:
+          token: ${{ steps.generate-token.outputs.token }}
+          fetch-depth: 0
+
+      - name: Determine new Tag
+        uses: mathieudutour/github-tag-action@v6.0
+        id: tag_version
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          pre_release_branches: develop
+          dry_run: true
+
+      - name: Generate Changelog
+        id: changelog
+        uses: mrchief/universal-changelog-action@v1.3.2
+        with:
+          previousReleaseTagNameOrSha: ${{ steps.tag_version.outputs.previous_tag }}
+          nextReleaseTagName: ${{ github.sha }}
+          nextReleaseName: "Release ${{ steps.tag_version.outputs.new_version }}"
+
+      - name: Update CHANGELOG.md
+        run: |
+          cat - CHANGELOG.md > temp <<'CHANGELOG.md-EOF'
+          ${{ steps.changelog.outputs.changelog }}
+          CHANGELOG.md-EOF
+          sed -i 's/releases\/tag\/${{ github.sha }}/releases\/tag\/${{ steps.tag_version.outputs.new_tag }}/g' temp
+          mv temp CHANGELOG.md
+
+      - name: Update package version
+        run: |
+          cargo install cargo-edit
+          cargo set-version ${{ steps.tag_version.outputs.new_version }}
+          make toml-tidy
+
+      - name: Commit and push CHANGELOG.md
+        env:
+          GITHUB_TOKEN: ${{ steps.generate-token.outputs.token }}
+          CHANGED_FILE: "CHANGELOG.md"
+          MESSAGE: "chore(ci): update changelog\n\n[skip ci]"
+        run: |
+          export CONTENT=$(base64 -i ${{ env.CHANGED_FILE }})
+          export SHA=$(git rev-parse ${{ github.ref_name }}:${{ env.CHANGED_FILE }})
+          gh api --method PUT /repos/:owner/:repo/contents/${{ env.CHANGED_FILE }} \
+            --field message="${{ env.MESSAGE }}" \
+            --field content="$CONTENT" \
+            --field encoding="base64" \
+            --field branch="${{ github.ref_name }}" \
+            --field sha="$SHA"
+
+      - name: Commit and push server Cargo.toml
+        env:
+          GITHUB_TOKEN: ${{ steps.generate-token.outputs.token }}
+          CHANGED_FILE: "server/Cargo.toml"
+          MESSAGE: "chore(ci): update package version\n\n[skip ci]"
+        run: |
+          export CONTENT=$(base64 -i ${{ env.CHANGED_FILE }})
+          export SHA=$(git rev-parse ${{ github.ref_name }}:${{ env.CHANGED_FILE }})
+          gh api --method PUT /repos/:owner/:repo/contents/${{ env.CHANGED_FILE }} \
+            --field message="${{ env.MESSAGE }}" \
+            --field content="$CONTENT" \
+            --field encoding="base64" \
+            --field branch="${{ github.ref_name }}" \
+            --field sha="$SHA"
+
+      - name: Commit and push client-grpc Cargo.toml
+        env:
+          GITHUB_TOKEN: ${{ steps.generate-token.outputs.token }}
+          CHANGED_FILE: "client-grpc/Cargo.toml"
+          MESSAGE: "chore(ci): update package version<br/><br/>[skip ci]"
+        run: |
+          export CONTENT=$(base64 -i ${{ env.CHANGED_FILE }})
+          export SHA=$(git rev-parse ${{ github.ref_name }}:${{ env.CHANGED_FILE }})
+          gh api --method PUT /repos/:owner/:repo/contents/${{ env.CHANGED_FILE }} \
+            --field message="${{ env.MESSAGE }}" \
+            --field content="$CONTENT" \
+            --field encoding="base64" \
+            --field branch="${{ github.ref_name }}" \
+            --field sha="$SHA"
+
+      - name: Push New Tag
+        uses: mathieudutour/github-tag-action@v6.0
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          custom_tag: ${{ steps.tag_version.outputs.new_version }}
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+        with:
+          platforms: 'amd64,arm64'
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@v4
+        with:
+          images: ghcr.io/${{ env.IMAGE_NAME }}
+          tags: |
+            type=ref,event=branch
+            type=ref,event=pr
+            type=semver,pattern={{version}},value=${{ steps.tag_version.outputs.new_tag }}
+            type=semver,pattern={{major}}.{{minor}},value=${{ steps.tag_version.outputs.new_tag }}
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v3
+        with:
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          platforms: linux/amd64,linux/arm64
+
+      - name: Clean Checkout
+        uses: actions/checkout@v3
+        with:
+          ref: ${{ github.ref_name }}
+
+      - name: Build and publish client
+        env:
+          PUBLISH_DRY_RUN: 0
+        run: |
+          make rust-publish
+
+      - name: Create Release
+        id: create_release
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: ${{ steps.tag_version.outputs.new_tag }}
+          release_name: Release ${{ steps.tag_version.outputs.new_version }}
+          body: ${{ steps.changelog.outputs.changelog }}
+          draft: false
+          prerelease: ${{ env.GITHUB_REF_NAME == 'develop' }}

--- a/src/templates/rust-svc/.github/workflows/release.yml
+++ b/src/templates/rust-svc/.github/workflows/release.yml
@@ -12,7 +12,7 @@ on:
 
 env:
   REGISTRY: ghcr.io
-  IMAGE_NAME: ${{ github.repository }}
+  PACKAGE_NAME: ${{ github.repository }}
   TERM: xterm
 
 jobs:
@@ -138,7 +138,7 @@ jobs:
         id: meta
         uses: docker/metadata-action@v4
         with:
-          images: ghcr.io/${{ env.IMAGE_NAME }}
+          images: ghcr.io/${{ env.PACKAGE_NAME }}
           tags: |
             type=ref,event=branch
             type=ref,event=pr

--- a/src/templates/rust-svc/Dockerfile
+++ b/src/templates/rust-svc/Dockerfile
@@ -1,6 +1,6 @@
 ## DO NOT EDIT!
 # This file was provisioned by Terraform
-# File origin: https://github.com/Arrow-air/tf-github/tree/main/src/templates/rust-all/Dockerfile
+# File origin: https://github.com/Arrow-air/tf-github/tree/main/src/templates/rust-svc/Dockerfile
 FROM --platform=$BUILDPLATFORM ghcr.io/arrow-air/tools/arrow-rust:latest AS build
 
 ENV CARGO_INCREMENTAL=1

--- a/src/templates/rust-svc/docker-compose.yml
+++ b/src/templates/rust-svc/docker-compose.yml
@@ -3,11 +3,12 @@ version: '3.6'
 services:
   web-server:
     container_name: ${PACKAGE_NAME}-run
-    image: ${IMAGE_NAME}:latest
+    image: ${PACKAGE_NAME}:latest
     ports:
-      - ${HOST_PORT}:${DOCKER_PORT}
+      - ${HOST_PORT_REST}:${DOCKER_PORT_REST}
+      - ${HOST_PORT_GRPC}:${DOCKER_PORT_GRPC}
     healthcheck:
-      test: ["CMD", "wget", "--spider", "--no-verbose", "--tries=1", "http://localhost:${DOCKER_PORT}/live"]
+      test: ["CMD", "wget", "--spider", "--no-verbose", "--tries=1", "http://localhost:${DOCKER_PORT_REST}/live"]
       interval: 2s
       timeout: 1s
       retries: 3
@@ -19,7 +20,7 @@ services:
       web-server:
         condition: service_healthy
     container_name: ${PACKAGE_NAME}-example
-    image: ${BUILD_IMAGE_NAME}:${BUILD_IMAGE_TAG}
+    image: ${RUST_IMAGE_NAME}:${RUST_IMAGE_TAG}
     volumes:
       - type: bind
         source: "${SOURCE_PATH}/"
@@ -29,6 +30,7 @@ services:
         target: "/usr/local/cargo/registry"
     environment:
       - HOSTNAME
-      - DOCKER_PORT
+      - SERVER_PORT_GRPC
+      - SERVER_PORT_REST
       - EXAMPLE_TARGET
     command: cargo run --manifest-path "${CARGO_MANIFEST_PATH}" --example "${EXAMPLE_TARGET}"


### PR DESCRIPTION
This PR will add a release workflow for all `rust-svc` repositories.
Most of the magic can be found here:
https://github.com/Arrow-air/tf-github/pull/56/files#diff-025c90e98d0cc2a8302c5d014b0c557f3556f1e9087823a9b24008d5ff864b55

Release process:
- Checkout PR target branch
- Get a list of all the commit messages part of the branch
- Determine which tag should be used based on the commit message subjects (semantic-release)
- Generate Changelog based on commit messages
- Bump package version to new tag
- Commit and push Changelog and package version changes
- Set tag on latest sha
- Build and push docker image with new tag
- Create Release in GitHub with new tag

The PR also adds some fixes for the docker-compose workflow to run rust example.

## TODO:

### Rebase after merge to main
After we've merged develop into main, we need to rebase develop with main since the CHANGELOG.md and Cargo.toml files will have been updated by the workflow.
We should be able to add this step to the release workflow, but it hasn't been added/ tested yet.

### Release notes
CHANGELOG.md and GitHub Release nodes now include the commit made by the Terraform bot as well. These should be filtered out.