### PR TITLE
fix: Update rust.mk to use $() instead of ``

### DIFF
--- a/.make/base.mk
+++ b/.make/base.mk
@@ -22,7 +22,7 @@ SGR0   := $(shell echo -e `tput sgr0`)
 docker_run = docker run \
 	--name=$(DOCKER_NAME)-$@ \
 	--rm \
-	--user `id -u`:`id -g` \
+	--user $(id -u):$(id -g) \
 	--workdir=/usr/src/app \
 	-v "$(SOURCE_PATH)/:/usr/src/app" \
 	$(2) \

--- a/.make/editorconfig.mk
+++ b/.make/editorconfig.mk
@@ -13,7 +13,7 @@ editorconfig-test:
 	@docker run \
 		--name=$(DOCKER_NAME)-$@ \
 		--rm \
-		--user `id -u`:`id -g` \
+		--user $(id -u):$(id -g) \
 		-w "/usr/src/app" \
 		-v "$(PWD):/usr/src/app" \
 		-t mstruebing/editorconfig-checker

--- a/.make/markdown.mk
+++ b/.make/markdown.mk
@@ -22,7 +22,7 @@ endif
 	@docker run \
 		--name=$(DOCKER_NAME)-$@ \
 		--rm \
-		--user `id -u`:`id -g` \
+		--user $(id -u):$(id -g) \
 		-w "/usr/src/app" \
 		-v "$(PWD):/usr/src/app" \
 		-t ghcr.io/tcort/markdown-link-check:stable \

--- a/src/templates/all/.make/base.mk
+++ b/src/templates/all/.make/base.mk
@@ -22,7 +22,7 @@ SGR0   := $(shell echo -e `tput sgr0`)
 docker_run = docker run \
 	--name=$(DOCKER_NAME)-$@ \
 	--rm \
-	--user `id -u`:`id -g` \
+	--user $(id -u):$(id -g) \
 	--workdir=/usr/src/app \
 	-v "$(SOURCE_PATH)/:/usr/src/app" \
 	$(2) \

--- a/src/templates/all/.make/editorconfig.mk
+++ b/src/templates/all/.make/editorconfig.mk
@@ -13,7 +13,7 @@ editorconfig-test:
 	@docker run \
 		--name=$(DOCKER_NAME)-$@ \
 		--rm \
-		--user `id -u`:`id -g` \
+		--user $(id -u):$(id -g) \
 		-w "/usr/src/app" \
 		-v "$(PWD):/usr/src/app" \
 		-t mstruebing/editorconfig-checker

--- a/src/templates/all/.make/markdown.mk
+++ b/src/templates/all/.make/markdown.mk
@@ -22,7 +22,7 @@ endif
 	@docker run \
 		--name=$(DOCKER_NAME)-$@ \
 		--rm \
-		--user `id -u`:`id -g` \
+		--user $(id -u):$(id -g) \
 		-w "/usr/src/app" \
 		-v "$(PWD):/usr/src/app" \
 		-t ghcr.io/tcort/markdown-link-check:stable \

--- a/src/templates/all/.make/rust.mk
+++ b/src/templates/all/.make/rust.mk
@@ -89,7 +89,7 @@ rust-test: check-cargo-registry rust-docker-pull
 rust-example-%: EXAMPLE_TARGET=$*
 rust-example-%: check-cargo-registry rust-docker-pull
 	@docker compose run \
-		--user `id -u`:`id -g` \
+		--user $(id -u):$(id -g) \
 		--rm \
 		-e CARGO_INCREMENTAL=1 \
 		-e RUSTC_BOOTSTRAP=0 \

--- a/src/templates/all/.make/rust.mk
+++ b/src/templates/all/.make/rust.mk
@@ -19,7 +19,7 @@ else
 cargo_run = docker run \
 	--name=$(DOCKER_NAME)-$@ \
 	--rm \
-	--user `id -u`:`id -g` \
+	--user $(id -u):$(id -g) \
 	--workdir=/usr/src/app \
 	-v "$(SOURCE_PATH)/:/usr/src/app" \
 	-v "$(SOURCE_PATH)/.cargo/registry:/usr/local/cargo/registry" \

--- a/src/templates/benchmarks/Makefile
+++ b/src/templates/benchmarks/Makefile
@@ -23,7 +23,7 @@ include .make/python.mk
 docker_run = docker run \
 	--name=$(DOCKER_NAME)-$@ \
 	--rm \
-	--user `id -u`:`id -g` \
+	--user $(id -u):$(id -g) \
 	-v "$(PWD):/usr/src/app" \
 	$(2) \
 	-t $(RUST_IMAGE_NAME):$(RUST_IMAGE_TAG) \


### PR DESCRIPTION
With the current implementation: if I do a `make rust-example-rest`, then try to do anything using `cargo_run` (like `make build`), I get a permissions error:
> amsmith@pop-os ~/git/arrow/svc-cargo (am-smith/dw-461/cargo) $ make rust-check
docker pull -q ghcr.io/arrow-air/tools/arrow-rust:1.0
Running cargo check...
    Updating git repository `https://github.com/Arrow-air/svc-scheduler/`
error: Permission denied (os error 13) at path "/usr/src/app/targetEtHm09"
make: *** [.make/rust.mk:83: rust-check] Error 101

Switching from backticks to $() for the --user option on `cargo_run` resolves the error

I don't believe Makefiles support backticks in general...

There are plenty of other instances of "--user \`id -u\`:\`id -g\`" in the other .mk files, but I haven't encountered issues with those at all

Can update the rest on request