### PR TITLE
fix(docker-compose): health check and env vars

### DIFF
--- a/src/templates/all/.make/rust.mk
+++ b/src/templates/all/.make/rust.mk
@@ -95,8 +95,8 @@ rust-example-%: check-cargo-registry rust-docker-pull
 		-e EXAMPLE_TARGET=$(EXAMPLE_TARGET) \
 		-e SERVER_PORT_GRPC=$(DOCKER_PORT_GRPC) \
 		-e SERVER_PORT_REST=$(DOCKER_PORT_REST) \
-		-e SERVER_HOSTNAME=$(DOCKER_NAME)-run \
-		example && docker compose stop
+		-e SERVER_HOSTNAME=$(DOCKER_NAME)-example-server \
+		example && docker compose down
 
 rust-clippy: check-cargo-registry rust-docker-pull
 	@echo "$(CYAN)Running clippy...$(SGR0)"

--- a/src/templates/all/.make/rust.mk
+++ b/src/templates/all/.make/rust.mk
@@ -8,7 +8,6 @@ CARGO_MANIFEST_PATH ?= Cargo.toml
 CARGO_INCREMENTAL   ?= 1
 RUSTC_BOOTSTRAP     ?= 0
 RELEASE_TARGET      ?= x86_64-unknown-linux-musl
-HOSTNAME            ?= $(DOCKER_NAME)-run
 PUBLISH_DRY_RUN     ?= 1
 
 # function with a generic template to run docker with the required values
@@ -96,6 +95,7 @@ rust-example-%: check-cargo-registry rust-docker-pull
 		-e EXAMPLE_TARGET=$(EXAMPLE_TARGET) \
 		-e SERVER_PORT_GRPC=$(DOCKER_PORT_GRPC) \
 		-e SERVER_PORT_REST=$(DOCKER_PORT_REST) \
+		-e SERVER_HOSTNAME=$(DOCKER_NAME)-run \
 		example && docker compose stop
 
 rust-clippy: check-cargo-registry rust-docker-pull

--- a/src/templates/rust-svc/Dockerfile
+++ b/src/templates/rust-svc/Dockerfile
@@ -10,8 +10,11 @@ COPY . /usr/src/app
 
 RUN cd /usr/src/app ; cargo build --release
 
+FROM --platform=$TARGETPLATFORM ghcr.io/grpc-ecosystem/grpc-health-probe:v0.4.14 AS grpc-health-probe
+
 FROM --platform=$TARGETPLATFORM alpine:latest
 ARG PACKAGE_NAME=
+COPY --from=grpc-health-probe /ko-app/grpc-health-probe /usr/local/bin/grpc_health_probe
 COPY --from=build /usr/src/app/target/release/${PACKAGE_NAME} /usr/local/bin/${PACKAGE_NAME}
 RUN ln -s /usr/local/bin/${PACKAGE_NAME} /usr/local/bin/server
 

--- a/src/templates/rust-svc/docker-compose.yml
+++ b/src/templates/rust-svc/docker-compose.yml
@@ -2,7 +2,7 @@
 version: '3.6'
 services:
   web-server:
-    container_name: ${DOCKER_NAME}-run
+    container_name: ${DOCKER_NAME}-example-server
     image: ${PACKAGE_NAME}:latest
     ports:
       - ${HOST_PORT_REST}:${DOCKER_PORT_REST}

--- a/src/templates/rust-svc/docker-compose.yml
+++ b/src/templates/rust-svc/docker-compose.yml
@@ -2,13 +2,13 @@
 version: '3.6'
 services:
   web-server:
-    container_name: ${PACKAGE_NAME}-run
+    container_name: ${DOCKER_NAME}-run
     image: ${PACKAGE_NAME}:latest
     ports:
       - ${HOST_PORT_REST}:${DOCKER_PORT_REST}
       - ${HOST_PORT_GRPC}:${DOCKER_PORT_GRPC}
     healthcheck:
-      test: ["CMD", "wget", "--spider", "--no-verbose", "--tries=1", "http://localhost:${DOCKER_PORT_REST}/live"]
+      test: ["CMD", "grpc_health_probe", "-addr", "localhost:${DOCKER_PORT_GRPC}"]
       interval: 2s
       timeout: 1s
       retries: 3
@@ -19,7 +19,7 @@ services:
     depends_on:
       web-server:
         condition: service_healthy
-    container_name: ${PACKAGE_NAME}-example
+    container_name: ${DOCKER_NAME}-example
     image: ${RUST_IMAGE_NAME}:${RUST_IMAGE_TAG}
     volumes:
       - type: bind
@@ -29,7 +29,7 @@ services:
         source: "${SOURCE_PATH}/.cargo/registry"
         target: "/usr/local/cargo/registry"
     environment:
-      - HOSTNAME
+      - SERVER_HOSTNAME
       - SERVER_PORT_GRPC
       - SERVER_PORT_REST
       - EXAMPLE_TARGET


### PR DESCRIPTION
After being able to run a full end-to-end test using the svc-template-rust repository which has the latest files provisioned by Terraform, I ran into a couple of bugs.
This PR should fix these issues. 
A related PR has been created on svc-template-rust, to have a fully working grpc example using the `make rust-example-grpc` command.