### PR TITLE
fix(release): deploy release workflow for svc

### DIFF
--- a/src/repositories_rust.tf
+++ b/src/repositories_rust.tf
@@ -28,8 +28,8 @@ locals {
         "docker-compose.yml" = {
           content = file("templates/rust-svc/docker-compose.yml")
         },
-        ".github/workflows/sanity_checks.yml" = {
-          content = file("templates/rust-all/.github/workflows/sanity_checks.yml")
+        ".github/workflows/release.yml" = {
+          content = file("templates/rust-svc/.github/workflows/release.yml")
         }
       }
     )


### PR DESCRIPTION
I noticed the release workflow was not properly added to the terraform configuration for the rust svc repositories.
The `sanity_checks.yaml` was a copy/paste from the `rust_default.files` but I'd forgotten to change it to the right file name.