### PR TITLE
Add Dockerfile for tool-simulation

### DIFF
--- a/src/main.tf
+++ b/src/main.tf
@@ -128,6 +128,11 @@ locals {
       webhooks       = try(local.webhooks["services"], {})
       repository_files = merge(
         local.rust_default.files,
+        {
+          "Dockerfile" = {
+            content = file("templates/rust-all/Dockerfile")
+          }
+        },
         { for file, path in local.rust_default.template_files :
           file => {
             content = templatefile(path, {

--- a/src/templates/rust-all/Dockerfile
+++ b/src/templates/rust-all/Dockerfile
@@ -1,0 +1,18 @@
+## DO NOT EDIT!
+# This file was provisioned by Terraform
+# File origin: https://github.com/Arrow-air/tf-github/tree/main/src/templates/rust-all/Dockerfile
+FROM --platform=$BUILDPLATFORM ghcr.io/arrow-air/tools/arrow-rust:latest AS build
+
+ENV CARGO_INCREMENTAL=1
+ENV RUSTC_BOOTSTRAP=0
+
+COPY . /usr/src/app
+
+RUN cd /usr/src/app ; cargo build --release
+
+FROM --platform=$TARGETPLATFORM alpine:latest
+ARG PACKAGE_NAME=
+COPY --from=build /usr/src/app/target/release/${PACKAGE_NAME} /usr/local/bin/${PACKAGE_NAME}
+RUN ln -s /usr/local/bin/${PACKAGE_NAME} /usr/local/bin/app
+
+ENTRYPOINT ["/usr/local/bin/app"]


### PR DESCRIPTION
`make build` in tool-simulation workflow is broken because no Dockerfile is provided

Created a different Dockerfile under rust-all for non-svc Rust repos