### PR TITLE
fix(rust-svc): release and docker make targets

### DIFF
--- a/src/templates/all/.make/rust.mk
+++ b/src/templates/all/.make/rust.mk
@@ -96,7 +96,7 @@ rust-example-%: check-cargo-registry rust-docker-pull
 		-e SERVER_PORT_GRPC=$(DOCKER_PORT_GRPC) \
 		-e SERVER_PORT_REST=$(DOCKER_PORT_REST) \
 		-e SERVER_HOSTNAME=$(DOCKER_NAME)-example-server \
-		example && docker compose down
+		example --remove-orphans && docker compose down
 
 rust-clippy: check-cargo-registry rust-docker-pull
 	@echo "$(CYAN)Running clippy...$(SGR0)"

--- a/src/templates/rust-svc/.github/workflows/release.yml
+++ b/src/templates/rust-svc/.github/workflows/release.yml
@@ -72,7 +72,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ steps.generate-token.outputs.token }}
           CHANGED_FILE: "CHANGELOG.md"
-          MESSAGE: "chore(ci): update changelog\n\n[skip ci]"
+          MESSAGE: "ci - update changelog\n\n[skip ci]"
         run: |
           export CONTENT=$(base64 -i ${{ env.CHANGED_FILE }})
           export SHA=$(git rev-parse ${{ github.ref_name }}:${{ env.CHANGED_FILE }})
@@ -87,7 +87,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ steps.generate-token.outputs.token }}
           CHANGED_FILE: "server/Cargo.toml"
-          MESSAGE: "chore(ci): update package version\n\n[skip ci]"
+          MESSAGE: "ci - update server package version\n\n[skip ci]"
         run: |
           export CONTENT=$(base64 -i ${{ env.CHANGED_FILE }})
           export SHA=$(git rev-parse ${{ github.ref_name }}:${{ env.CHANGED_FILE }})
@@ -102,7 +102,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ steps.generate-token.outputs.token }}
           CHANGED_FILE: "client-grpc/Cargo.toml"
-          MESSAGE: "chore(ci): update package version<br/><br/>[skip ci]"
+          MESSAGE: "ci - update client-grpc package version\n\n[skip ci]"
         run: |
           export CONTENT=$(base64 -i ${{ env.CHANGED_FILE }})
           export SHA=$(git rev-parse ${{ github.ref_name }}:${{ env.CHANGED_FILE }})
@@ -153,7 +153,7 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           platforms: linux/amd64,linux/arm64
           build-args: |
-            PACKAGE_NAME: ${{ env.PACKAGE_NAME }}
+            PACKAGE_NAME=${{ github.event.repository.name }}
 
       - name: Clean Checkout
         uses: actions/checkout@v3

--- a/src/templates/rust-svc/Dockerfile
+++ b/src/templates/rust-svc/Dockerfile
@@ -8,7 +8,9 @@ ENV RUSTC_BOOTSTRAP=0
 
 COPY . /usr/src/app
 
-RUN cd /usr/src/app ; cargo build --release
+# perl and build-base are needed to build openssl, see:
+# https://github.com/openssl/openssl/blob/master/INSTALL.md#prerequisites
+RUN apk -U add perl build-base ; cd /usr/src/app ; cargo build --release --features=vendored-openssl
 
 FROM --platform=$TARGETPLATFORM ghcr.io/grpc-ecosystem/grpc-health-probe:v0.4.14 AS grpc-health-probe
 


### PR DESCRIPTION
The release pipeline still had some issues which have been manually fixed. This PR should make sure the manual fixes don't get overwritten when running Terraform again.
From the Dework task:

- [x] The templates/rust-svc/.github/workflows/release.yml file needs an additional fix to build the docker images after release.
- [x] The GitHub release app needs to be added to the PR bypassers list for the `main` and the `develop` branches.
- [x] The templates/all/.make/rust.mk file needs a fix for the `rust-example-%` target so it will remove orphans when docker-compose runs.
- [x] Since the Dockerfile needed an update for svc-storage to work (https://github.com/Arrow-air/svc-storage/pull/6/files), we’ll need to update tf-github as well to make sure Terraform won’t overwrite these changes.