### PR TITLE
feat(web-nuxt): add web repositories and resources

### DIFF
--- a/.cspell.project-words.txt
+++ b/.cspell.project-words.txt
@@ -26,3 +26,5 @@ yapf
 commitlint
 commitlintrc
 healthcheck
+Nuxt
+nuxt

--- a/src/main.tf
+++ b/src/main.tf
@@ -1,4 +1,9 @@
+data "github_app" "arrow_tf_github_repositories" {
+  slug = "arrow-tf-github-repositories"
+}
+
 locals {
+  arrow_release_automation_node_id = data.github_app.arrow_tf_github_repositories.node_id
   # Secret provided by Terraform Cloud configuration on the workspace
   discord_services_integration_url = sensitive(var.discord_services_integration_url)
 
@@ -163,11 +168,12 @@ module "repository" {
   source   = "./modules/github-repository/"
   for_each = local.repos
 
-  name           = each.key
-  description    = each.value.description
-  visibility     = each.value.visibility
-  default_branch = try(each.value.default_branch, "main")
-  webhooks       = try(each.value.webhooks, {})
+  name                  = each.key
+  description           = each.value.description
+  visibility            = each.value.visibility
+  default_branch        = try(each.value.default_branch, "main")
+  webhooks              = try(each.value.webhooks, {})
+  terraform_app_node_id = local.arrow_release_automation_node_id
 
   repository_files = merge(
     local.files,

--- a/src/modules/github-repository/variables.tf
+++ b/src/modules/github-repository/variables.tf
@@ -1,7 +1,6 @@
 variable "terraform_app_node_id" {
-  description = "Node ID of terraform app, This node ID is found by querying the GitHub API `gh api -H \"Accept: application/vnd.github+json\" /apps/arrow-tf-github-repositories`"
+  description = "Node ID of terraform app, This node ID is found by querying the GitHub API `gh api -H \"Accept: application/vnd.github+json\" /apps/<your app slug>`"
   type        = string
-  default     = "A_kwHOBayTi84AAq0w"
 }
 
 variable "github_owner" {

--- a/src/repositories_nuxt.tf
+++ b/src/repositories_nuxt.tf
@@ -1,0 +1,127 @@
+#####################################################################
+#
+# Repository settings for Arrow Web Applications
+#
+#####################################################################
+locals {
+  # Repositories needed for shared Nuxt Components can be listed here
+  nuxt_mod = {
+    template_files = local.nuxt_default.template_files
+    files          = local.nuxt_default.files
+
+    repos = {
+    }
+  }
+
+  # Repositories needed for our Web Applications can be listed here
+  nuxt_web = {
+    template_files = local.nuxt_default.template_files
+    files = merge(
+      local.nuxt_default.files, {
+      }
+    )
+
+    repos = {
+      "cargo-shipper" = {
+        description = "Cargo Shipper"
+      }
+    }
+  }
+
+  nuxt_default = {
+    template_files = merge(local.template_files, {
+    })
+
+    files = merge(local.files, {
+      ".gitignore" = {
+        content = file("templates/nuxt-all/.gitignore")
+      }
+      ".husky/pre-commit" = {
+        content = file("templates/nuxt-all/.husky/pre-commit")
+      },
+      ".husky/commit-msg" = {
+        content = file("templates/nuxt-all/.husky/commit-msg")
+      },
+      #".github/workflows/nuxt_ci.yml" = {
+      # content = file("templates/nuxt-all/.github/workflows/nuxt_ci.yml")
+      #},
+      ".github/workflows/sanity_checks.yml" = {
+        content = file("templates/nuxt-all/.github/workflows/sanity_checks.yml")
+      }
+    })
+
+    settings = {
+      owner_team                         = "services"
+      visibility                         = "public"
+      default_branch                     = "develop"
+      webhooks                           = try(local.webhooks["services"], {})
+      default_branch_protection_settings = {} # Using module defaults
+    }
+  }
+}
+
+########################################################
+# Rust Library repositories
+########################################################
+module "repository_nuxt_mod" {
+  source   = "./modules/github-repository/"
+  for_each = { for key, settings in local.nuxt_mod.repos : key => merge(local.nuxt_default.settings, settings) }
+
+  name        = format("mod-%s", each.key)
+  description = format("Arrow Nuxt Module - %s", each.value.description)
+  template    = module.repository_mod_template["nuxt"].repository.name
+  repository_files = merge(
+    local.nuxt_mod.files,
+    { for file, path in local.nuxt_mod.template_files :
+      file => {
+        content = templatefile(path, {
+          owner_team = each.value.owner_team
+          type       = "mod"
+          name       = format("mod-%s", each.key)
+        })
+      }
+    }
+  )
+
+  # Settings with defaults
+  owner_team            = each.value.owner_team
+  visibility            = each.value.visibility
+  default_branch        = each.value.default_branch
+  webhooks              = each.value.webhooks
+  terraform_app_node_id = local.arrow_release_automation_node_id
+
+  default_branch_protection_settings = each.value.default_branch_protection_settings
+}
+
+########################################################
+# Rust Services repositories
+########################################################
+module "repository_nuxt_web" {
+  source   = "./modules/github-repository/"
+  for_each = { for key, settings in local.nuxt_web.repos : key => merge(local.nuxt_default.settings, settings) }
+
+  name        = format("web-%s", each.key)
+  description = format("Arrow Web Application - %s", each.value.description)
+  template    = module.repository_web_template["nuxt"].repository.name
+  repository_files = merge(
+    local.nuxt_web.files,
+    { for file, path in local.nuxt_web.template_files :
+      file => {
+        content = templatefile(path, {
+          owner_team = each.value.owner_team
+          type       = "web"
+          name       = format("web-%s", each.key)
+        })
+      }
+    }
+  )
+
+  # Settings with defaults
+  owner_team            = each.value.owner_team
+  visibility            = each.value.visibility
+  default_branch        = each.value.default_branch
+  webhooks              = each.value.webhooks
+  terraform_app_node_id = local.arrow_release_automation_node_id
+
+  default_branch_protection_settings = each.value.default_branch_protection_settings
+}

--- a/src/repositories_rust.tf
+++ b/src/repositories_rust.tf
@@ -19,14 +19,6 @@ locals {
   }
 
   rust_svc = {
-    settings = {
-      default_branch_protection_settings = {
-        required_pull_request_reviews = {
-          # Allow release automation app to update CHANGELOG.md and Cargo.toml files
-          pull_request_bypassers = ["A_kwHOBayTi84AA8vv"]
-        }
-      }
-    }
     template_files = local.rust_default.template_files
     files = merge(
       local.rust_default.files, {
@@ -158,10 +150,11 @@ module "repository_rust_lib" {
   )
 
   # Settings with defaults
-  owner_team     = each.value.owner_team
-  visibility     = each.value.visibility
-  default_branch = each.value.default_branch
-  webhooks       = each.value.webhooks
+  owner_team            = each.value.owner_team
+  visibility            = each.value.visibility
+  default_branch        = each.value.default_branch
+  webhooks              = each.value.webhooks
+  terraform_app_node_id = local.arrow_release_automation_node_id
 
   default_branch_protection_settings = each.value.default_branch_protection_settings
 }
@@ -192,10 +185,11 @@ module "repository_rust_svc" {
   )
 
   # Settings with defaults
-  owner_team     = each.value.owner_team
-  visibility     = each.value.visibility
-  default_branch = each.value.default_branch
-  webhooks       = each.value.webhooks
+  owner_team            = each.value.owner_team
+  visibility            = each.value.visibility
+  default_branch        = each.value.default_branch
+  webhooks              = each.value.webhooks
+  terraform_app_node_id = local.arrow_release_automation_node_id
 
   default_branch_protection_settings = each.value.default_branch_protection_settings
 }

--- a/src/repositories_terraform.tf
+++ b/src/repositories_terraform.tf
@@ -50,10 +50,11 @@ module "repository_tf" {
   description = format("Arrow Terraform - %s", each.value.description)
 
   # Settings with defaults
-  owner_team     = each.value.owner_team
-  visibility     = each.value.visibility
-  default_branch = each.value.default_branch
-  webhooks       = each.value.webhooks
+  owner_team            = each.value.owner_team
+  visibility            = each.value.visibility
+  default_branch        = each.value.default_branch
+  webhooks              = each.value.webhooks
+  terraform_app_node_id = local.arrow_release_automation_node_id
 
   repository_files = merge(
     local.terraform_default.files,

--- a/src/templates/all/.commitlintrc.yml
+++ b/src/templates/all/.commitlintrc.yml
@@ -1,3 +1,8 @@
+---
+## DO NOT EDIT!
+## This file was provisioned by Terraform
+## File origin: https://github.com/Arrow-air/tf-github/tree/main/src/templates/all/.commitlintrc.yml
+
 rules:
   body-leading-blank: [1, always]
   body-max-line-length: [2, always, 100]

--- a/src/templates/nuxt-all/.github/workflows/sanity_checks.yml
+++ b/src/templates/nuxt-all/.github/workflows/sanity_checks.yml
@@ -1,0 +1,72 @@
+## DO NOT EDIT!
+# This file was provisioned by Terraform
+# File origin: https://github.com/Arrow-air/tf-github/tree/main/src/templates/nuxt-all/.github/workflows/sanity_checks.yml
+
+name: Sanity checks
+
+env:
+  TERM: xterm
+
+on:
+  pull_request:
+
+jobs:
+  codestyle:
+    name: Code Style Check
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - run: make editorconfig-test
+
+  cspell:
+    name: Spelling Check
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - run: make cspell-test
+
+  md-test:
+    name: Markdown Broken Link Checker
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - run: make md-test-links
+
+  commit-msg:
+    name: Commit message Check
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - run: npx commitlint --from=${{ github.event.pull_request.base.sha }}
+
+  release-notes:
+    name: Preview Release Notes
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - name: Generate Changelog
+        id: changelog
+        uses: mrchief/universal-changelog-action@v1.3.1
+        with:
+          previousReleaseTagNameOrSha: ${{ github.event.pull_request.base.sha }}
+          nextReleaseTagName: ${{ github.sha }}
+          nextReleaseName: "Release ${{ steps.tag_version.outputs.new_version }}"
+
+      - name: Add PR Comment with Changelog Output
+        uses: thollander/actions-comment-pull-request@v1
+        continue-on-error: true
+        with:
+          message: |
+            <details>
+            <summary>This PR will generate the following release notes when merged:</summary>
+
+            ${{ steps.changelog.outputs.changelog }}
+
+            </details>
+          comment_includes: 'This PR will generate the following release notes when merged'

--- a/src/templates/nuxt-all/.gitignore
+++ b/src/templates/nuxt-all/.gitignore
@@ -1,0 +1,25 @@
+## DO NOT EDIT!
+# This file was provisioned by Terraform
+# File origin: https://github.com/Arrow-air/tf-github/tree/main/src/templates/nuxt-all/.gitignore
+
+# Dependencies
+node_modules
+
+# Nuxt build and generate output dirs
+.nuxt
+dist
+
+# Logs
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+
+# Don't add vscode or idea meta files
+.vscode
+.idea
+
+# Don't add DS_Store
+.DS_Store
+
+# env
+.env

--- a/src/templates/nuxt-all/.husky/commit-msg
+++ b/src/templates/nuxt-all/.husky/commit-msg
@@ -1,0 +1,8 @@
+#!/bin/sh
+## DO NOT EDIT!
+# This file was provisioned by Terraform
+# File origin: https://github.com/Arrow-air/tf-github/tree/main/src/templates/nuxt-all/.husky/hooks/commit-msg
+. "$(dirname -- "$0")/_/husky.sh"
+
+export COMMITLINT_CHECK=${1}
+make commitlint-test

--- a/src/templates/nuxt-all/.husky/pre-commit
+++ b/src/templates/nuxt-all/.husky/pre-commit
@@ -1,0 +1,22 @@
+#!/bin/sh
+## DO NOT EDIT!
+# This file was provisioned by Terraform
+# File origin: https://github.com/Arrow-air/tf-github/tree/main/src/templates/nuxt-all/.husky/hooks/pre-commit
+. "$(dirname -- "$0")/_/husky.sh"
+
+# Style templates for console output.
+GREEN=$(tput setaf 2)
+YELLOW=$(tput setaf 3)
+NC=$(tput setaf 9)
+BOLD=$(tput bold)
+SGR0=$(tput sgr0)
+
+echo -e "${BOLD}${YELLOW}Running the pre-commit hook...${NC}${SGR0}"
+
+set -e
+
+# Tests
+make test
+
+# Finish
+echo "${BOLD}${GREEN}🍺 You are good to go!${NC}${SGR0}"


### PR DESCRIPTION
Adding files and resources for nuxt repositories.
The template repository will be expanded later, once we have created a good setup in the `web-cargo-shipper` nuxt repository.

Also fixing release automation by just using the Terraform Github App.
Apps are not allowed to access other private app's in the organization, thus making it impossible for the Terraform Github App to check on the Release automation app's ID to add it to the list of commit bypasses.
For now, we'll just release with the Terraform App itself, which already has the right permissions.