### PR TITLE
chore(.env): restructured .env file handling

### DIFF
--- a/src/main.tf
+++ b/src/main.tf
@@ -133,7 +133,7 @@ locals {
       webhooks       = try(local.webhooks["services"], {})
       repository_files = merge(
         local.rust_default.files,
-        { for file, path in local.rust_default.template_files :
+        { for file, path in local.rust_svc.template_files :
           file => {
             content = templatefile(path, {
               owner_team = "services"

--- a/src/repositories_rust.tf
+++ b/src/repositories_rust.tf
@@ -5,8 +5,14 @@
 #####################################################################
 locals {
   rust_lib = {
-    template_files = local.rust_default.template_files
-    files          = local.rust_default.files
+    template_files = merge(local.rust_default.template_files, {
+      ".env.base.tftpl" = "templates/rust-lib/.env.base.tftpl"
+      "Makefile"        = "templates/rust-lib/Makefile"
+    })
+    files = merge(
+      local.rust_default.files, {
+      },
+    )
 
     repos = {
       "router" = {
@@ -19,7 +25,10 @@ locals {
   }
 
   rust_svc = {
-    template_files = local.rust_default.template_files
+    template_files = merge(local.rust_default.template_files, {
+      ".env.base.tftpl" = "templates/rust-svc/.env.base.tftpl"
+      "Makefile"        = "templates/rust-svc/Makefile"
+    })
     files = merge(
       local.rust_default.files, {
         "Dockerfile" = {
@@ -65,13 +74,15 @@ locals {
 
   rust_default = {
     template_files = merge(local.template_files, {
-      "Makefile"   = "templates/rust-all/Makefile.tftpl"
       ".gitignore" = "templates/rust-all/.gitignore.tftpl"
     })
 
     files = merge(local.files, {
       ".make/docker.mk" = {
         content = file("templates/all/.make/docker.mk")
+      },
+      ".make/env.mk" = {
+        content = file("templates/all/.make/env.mk")
       },
       ".make/python.mk" = {
         content = file("templates/all/.make/python.mk")

--- a/src/templates/all/.make/docker.mk
+++ b/src/templates/all/.make/docker.mk
@@ -16,7 +16,7 @@ docker-build:
 
 docker-run: docker-stop
 	# Run docker container as a daemon and map a port
-	@docker run --rm -d -p $(HOST_PORT_GRPC):$(DOCKER_PORT_GRPC) -p $(HOST_PORT_REST):$(DOCKER_PORT_REST) --name=$(DOCKER_NAME)-run $(PACKAGE_NAME):latest
+	@docker run --rm -d --env-file .env -p $(HOST_PORT_GRPC):$(DOCKER_PORT_GRPC) -p $(HOST_PORT_REST):$(DOCKER_PORT_REST) --name=$(DOCKER_NAME)-run $(PACKAGE_NAME):latest
 	@echo "$(YELLOW)Docker running and listening to http://localhost:$(HOST_PORT_GRPC) and http://localhost:$(HOST_PORT_REST) $(SGR0)"
 
 docker-stop:

--- a/src/templates/all/.make/env.mk
+++ b/src/templates/all/.make/env.mk
@@ -1,0 +1,19 @@
+## DO NOT EDIT!
+# This file was provisioned by Terraform
+# File origin: https://github.com/Arrow-air/tf-github/tree/main/src/templates/all/.make/env.mk
+
+ENV_FILE := $(wildcard .env .env.base)
+# If .env is missing, install .env.base+.env.repo as .env and load that.
+ifeq ($(ENV_FILE),.env.base)
+$(warning Settings file '.env' missing: '$(ENV_FILE)' => installing .env as merge of .env.base + .env.repo!)
+$(shell cat .env.base .env.repo > .env 2>/dev/null)
+endif
+
+# Sanity check, make sure keys from base and repo are present.
+# Strip empty lines and comments, get sorted keys (e.g. DOCKER_NAME)
+ENV_KEYS=$(shell grep -Ehv '^\s*(#.*)?\s*$$' .env.base .env.repo 2>/dev/null | cut -f1 -d= | sort)
+# Check if key exists in .env, if not grep it from the .env.base/repo into your .env
+$(foreach k, $(ENV_KEYS), $(eval $(shell sh -c "grep -q '^$(k)=' .env 2>/dev/null || (echo '*** NOTE: Adding missing .env key [$(k)] to your .env file!' 1>&2 ; grep -h '^$(k)=' .env.base .env.repo 2>/dev/null >> .env ; grep '^$(k)=' .env 1>&2)")))
+
+-include $(ENV_FILE)
+

--- a/src/templates/rust-lib/.env.base.tftpl
+++ b/src/templates/rust-lib/.env.base.tftpl
@@ -1,0 +1,7 @@
+## DO NOT EDIT!
+# This file was provisioned by Terraform
+# File origin: https://github.com/Arrow-air/tf-github/tree/main/src/templates/rust-lib/.env.base.tftpl
+
+DOCKER_NAME=arrow-${name}
+PACKAGE_NAME=${name}
+PUBLISH_PACKAGE_NAME=${name}

--- a/src/templates/rust-lib/Makefile
+++ b/src/templates/rust-lib/Makefile
@@ -1,28 +1,12 @@
 ## DO NOT EDIT!
 # This file was provisioned by Terraform
-# File origin: https://github.com/Arrow-air/tf-github/tree/main/src/templates/rust-all/Makefile.tftpl
+# File origin: https://github.com/Arrow-air/tf-github/tree/main/src/templates/rust-lib/Makefile
 
-DOCKER_NAME          := arrow-${name}
-PACKAGE_NAME         := ${name}
-%{ if type == "lib" }
-PUBLISH_PACKAGE_NAME := ${name}
+include .make/env.mk
+export
 
 help: .help-base .help-rust .help-python .help-cspell .help-markdown .help-editorconfig .help-commitlint .help-toml
 build: rust-build
-%{ else }
-PUBLISH_PACKAGE_NAME := ${name}-client-grpc
-DOCKER_PORT_REST     := 8000
-DOCKER_PORT_GRPC     := 50051
-HOST_PORT_REST       := ${port_rest}
-HOST_PORT_GRPC       := ${port_grpc}
-
-help: .help-base .help-rust .help-python .help-cspell .help-markdown .help-editorconfig .help-commitlint .help-toml .help-docker
-build: rust-build docker-build
-
-include .make/docker.mk
-%{ endif }
-export
-
 clean: rust-clean
 release: rust-release
 publish: rust-publish

--- a/src/templates/rust-svc/.env.base.tftpl
+++ b/src/templates/rust-svc/.env.base.tftpl
@@ -1,0 +1,11 @@
+## DO NOT EDIT!
+# This file was provisioned by Terraform
+# File origin: https://github.com/Arrow-air/tf-github/tree/main/src/templates/rust-svc/.env.base.tftpl
+
+DOCKER_NAME=arrow-${name}
+PACKAGE_NAME=${name}
+PUBLISH_PACKAGE_NAME=${name}-client-grpc
+DOCKER_PORT_REST=8000
+DOCKER_PORT_GRPC=50051
+HOST_PORT_REST=${port_rest}
+HOST_PORT_GRPC=${port_grpc}

--- a/src/templates/rust-svc/Makefile
+++ b/src/templates/rust-svc/Makefile
@@ -1,0 +1,25 @@
+## DO NOT EDIT!
+# This file was provisioned by Terraform
+# File origin: https://github.com/Arrow-air/tf-github/tree/main/src/templates/rust-svc/Makefile
+
+include .make/env.mk
+export
+
+help: .help-base .help-rust .help-python .help-cspell .help-markdown .help-editorconfig .help-commitlint .help-toml .help-docker
+build: rust-build docker-build
+clean: rust-clean
+release: rust-release
+publish: rust-publish
+test: rust-test-all cspell-test toml-test python-test md-test-links editorconfig-test
+tidy: rust-tidy toml-tidy python-tidy editorconfig-tidy
+all: clean test build release publish
+
+include .make/docker.mk
+include .make/base.mk
+include .make/cspell.mk
+include .make/markdown.mk
+include .make/editorconfig.mk
+include .make/commitlint.mk
+include .make/toml.mk
+include .make/rust.mk
+include .make/python.mk


### PR DESCRIPTION
 * `.env` files are now pulled into make (by `.make/env.mk`), so runtime variables only have to be defined in one place
 * terraform deploys a `.env.base` for the rust-svc and rust-lib repos that contains some base settings such as ports and package/docker names
 * each repo can optionally have their repo-specific settings in a `.env.repo` file
 * Whenever 'make' runs it'll check for the presence of a `.env` file, if missing it'll concatenate both `.env.base` and `.env.repo` and write this to `.env` for hopefully sane defaults. In case new settings are added later to the terraform-managed files they also get picked up as new keys by make and will automagically be added to the local .env file. 
 * This also means the Makefile for rust-svc and rust-lib can be generic without if statements