### PR TITLE
fix(.env): remove tftpl ending

### DIFF
--- a/src/repositories_rust.tf
+++ b/src/repositories_rust.tf
@@ -6,8 +6,8 @@
 locals {
   rust_lib = {
     template_files = merge(local.rust_default.template_files, {
-      ".env.base.tftpl" = "templates/rust-lib/.env.base.tftpl"
-      "Makefile"        = "templates/rust-lib/Makefile"
+      ".env.base" = "templates/rust-lib/.env.base.tftpl"
+      "Makefile"  = "templates/rust-lib/Makefile"
     })
     files = merge(
       local.rust_default.files, {
@@ -26,8 +26,8 @@ locals {
 
   rust_svc = {
     template_files = merge(local.rust_default.template_files, {
-      ".env.base.tftpl" = "templates/rust-svc/.env.base.tftpl"
-      "Makefile"        = "templates/rust-svc/Makefile"
+      ".env.base" = "templates/rust-svc/.env.base.tftpl"
+      "Makefile"  = "templates/rust-svc/Makefile"
     })
     files = merge(
       local.rust_default.files, {


### PR DESCRIPTION
Last TF push produced a file named `.env.base.tftpl` in all svc repos: https://github.com/Arrow-air/svc-cargo/commit/89a18274632c2f62b52d4ae31a93838921dae0ab

Since .env.base wasn't found, weird stuff:
![image](https://user-images.githubusercontent.com/6334638/202809411-6cf7f331-94d7-4c59-8151-0328fc33eef0.png)

