### PR TITLE
fix(provider): github provider bug in 5.9.0

### DIFF
--- a/src/versions.tf
+++ b/src/versions.tf
@@ -2,8 +2,9 @@ terraform {
   required_version = ">= 1.3"
   required_providers {
     github = {
-      source  = "integrations/github"
-      version = "~> 5.3"
+      source = "integrations/github"
+      # https://github.com/integrations/terraform-provider-github/issues/1373
+      version = "!= 5.9.0"
     }
   }
 }


### PR DESCRIPTION
There seems to be a but in our latest provider, causing issues in applying our plans:
https://github.com/integrations/terraform-provider-github/issues/1373