### PR TITLE
fix(lock): ship lock file to pin version

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -20,7 +20,7 @@ indent_size = 2
 trim_trailing_whitespace = false
 indent_style = space
 indent_size = 4
-[*.tf]
+[{*.tf,*.hcl}]
 indent_size = 2
 [{Makefile*,*.mk,*.sh}]
 indent_style = tab

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 # Terraform cache files
-.terraform*
+*/.terraform/**
 terraform.tfstate*
 
 # Don't add vscode meta files

--- a/src/.terraform.lock.hcl
+++ b/src/.terraform.lock.hcl
@@ -1,0 +1,24 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/integrations/github" {
+  version     = "5.8.0"
+  constraints = "~> 5.3, ~> 5.8.0"
+  hashes = [
+    "h1:o2mkZdXSPF44KcdEWoJwttP4FNDzkOnmPu61dLTR5JY=",
+    "zh:024c8e75571ae5008bf564a9f26da5eb1492517711ef1b67e96d6b001045d7cd",
+    "zh:3cb5eb4969c8b14cdee90f34f658b55956ffcdb6b7af6436a8e4f56712bb61fa",
+    "zh:3f9635e7cd45c8cb713e7cf9647ae323b44efedc02ef14e4645f19bda572f300",
+    "zh:482967c69fbf686db689c66e7232dd355da9b32e3bcf723a95ed734265003811",
+    "zh:4b3647bfc143f5952e52d4c954181a154bc06bc0215a0f6751a1bd7f69093d02",
+    "zh:9b3a59fbb2e56f32c15614bc3a8c9cb13a95fd62d85920bf65f283c0320da422",
+    "zh:ad0bf20b32f8371eef2cb0fa7d66982c7691779ec7148b43dd214927a545d5c0",
+    "zh:afb05def945873f94973d8f6b945fdfa6a554d8714a37b933f06e517a9bde113",
+    "zh:ba83a17aec01d244b912e2cabc8e2a27a09af688c925d8ae0e4442615cc4dd61",
+    "zh:c8e84aebcad70b767c466d6883a8dcdb8624053f15c2317c4fd4da46917805c2",
+    "zh:ca9505eb3808cadf1415e943bee40ba0176fa2bd30a094b792fbae391de9efe8",
+    "zh:cacd6f169a90f5203a68a6a2e7986dfd89813dbbf6b1dbdf4d65b47bb582a8c8",
+    "zh:ee90cce713d7aa8b5f9950044d3ec57aa3b0fd8383860ef825d8ed4aa83965c7",
+    "zh:fbdde8b13c2474fb3c53a9db90584ba5f214c3973fbf73538cef4922419940a6",
+  ]
+}

--- a/src/versions.tf
+++ b/src/versions.tf
@@ -4,7 +4,7 @@ terraform {
     github = {
       source = "integrations/github"
       # https://github.com/integrations/terraform-provider-github/issues/1373
-      version = "!= 5.9.0"
+      version = "~> 5.8.0"
     }
   }
 }


### PR DESCRIPTION
We don't want the provider version 5.9.x yet, as it still seems to be broken.
Shipping the lock file to git this time as well, so github actions won't automatically pick a newer version.