### PR TITLE
feat(rust): add LICENSE file

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -9,7 +9,7 @@ trim_trailing_whitespace = true
 insert_final_newline = true
 indent_style = space
 indent_size = 4
-[{*.md,*.mdx}]
+[{*.md,*.mdx,LICENSE*}]
 # double whitespace at end of line
 # denotes a line break in Markdown
 indent_size = off

--- a/src/repositories_rust.tf
+++ b/src/repositories_rust.tf
@@ -78,6 +78,7 @@ locals {
   rust_default = {
     template_files = merge(local.template_files, {
       ".gitignore" = "templates/rust-all/.gitignore.tftpl"
+      ".LICENSE"   = "templates/rust-all/LICENSE.tftpl"
     })
 
     files = merge(local.files, {

--- a/src/templates/all/.editorconfig
+++ b/src/templates/all/.editorconfig
@@ -9,7 +9,7 @@ trim_trailing_whitespace = true
 insert_final_newline = true
 indent_style = space
 indent_size = 4
-[{*.md,*.mdx}]
+[{*.md,*.mdx,LICENSE*}]
 # double whitespace at end of line
 # denotes a line break in Markdown
 indent_size = off

--- a/src/templates/rust-all/LICENSE.tftpl
+++ b/src/templates/rust-all/LICENSE.tftpl
@@ -1,0 +1,101 @@
+Business Source License 1.1
+
+License text copyright (c) 2017 MariaDB Corporation Ab, All Rights Reserved.
+"Business Source License" is a trademark of MariaDB Corporation Ab.
+
+-----------------------------------------------------------------------------
+
+Parameters
+
+Licensor:             Arrow DAO
+
+Licensed Work:        Arrow Services
+                      The Licensed Work is (c) 2022 Arrow DAO
+
+Additional Use Grant: Limited production uses, or as otherwise permitted by
+                      Arrow DAO governance vote
+
+Change Date:          for each release of ${name}, the earlier of (i) two
+                      years from the release date, or (ii) a date specified at
+                      https://github.com/Arrow-air/${name}/blob/main/README.md
+
+Change License:       GNU Affero General Public License v3.0 or later
+
+-----------------------------------------------------------------------------
+
+Terms
+
+The Licensor hereby grants you the right to copy, modify, create derivative
+works, redistribute, and make non-production use of the Licensed Work. The
+Licensor may make an Additional Use Grant, above, permitting limited
+production use.
+
+Effective on the Change Date, or the fourth anniversary of the first publicly
+available distribution of a specific version of the Licensed Work under this
+License, whichever comes first, the Licensor hereby grants you rights under
+the terms of the Change License, and the rights granted in the paragraph
+above terminate.
+
+If your use of the Licensed Work does not comply with the requirements
+currently in effect as described in this License, you must purchase a
+commercial license from the Licensor, its affiliated entities, or authorized
+resellers, or you must refrain from using the Licensed Work.
+
+All copies of the original and modified Licensed Work, and derivative works
+of the Licensed Work, are subject to this License. This License applies
+separately for each version of the Licensed Work and the Change Date may vary
+for each version of the Licensed Work released by Licensor.
+
+You must conspicuously display this License on each original or modified copy
+of the Licensed Work. If you receive the Licensed Work in original or
+modified form from a third party, the terms and conditions set forth in this
+License apply to your use of that work.
+
+Any use of the Licensed Work in violation of this License will automatically
+terminate your rights under this License for the current and all other
+versions of the Licensed Work.
+
+This License does not grant you any right in any trademark or logo of
+Licensor or its affiliates (provided that you may use a trademark or logo of
+Licensor as expressly required by this License).
+
+TO THE EXTENT PERMITTED BY APPLICABLE LAW, THE LICENSED WORK IS PROVIDED ON
+AN "AS IS" BASIS. LICENSOR HEREBY DISCLAIMS ALL WARRANTIES AND CONDITIONS,
+EXPRESS OR IMPLIED, INCLUDING (WITHOUT LIMITATION) WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, NON-INFRINGEMENT, AND
+TITLE.
+
+MariaDB hereby grants you permission to use this License’s text to license
+your works, and to refer to it using the trademark "Business Source License",
+as long as you comply with the Covenants of Licensor below.
+
+-----------------------------------------------------------------------------
+
+Covenants of Licensor
+
+In consideration of the right to use this License’s text and the "Business
+Source License" name and trademark, Licensor covenants to MariaDB, and to all
+other recipients of the licensed work to be provided by Licensor:
+
+1. To specify as the Change License the GPL Version 2.0 or any later version,
+   or a license that is compatible with GPL Version 2.0 or a later version,
+   where "compatible" means that software provided under the Change License can
+   be included in a program with software provided under GPL Version 2.0 or a
+   later version. Licensor may specify additional Change Licenses without
+   limitation.
+
+2. To either: (a) specify an additional grant of rights to use that does not
+   impose any additional restriction on the right granted in this License, as
+   the Additional Use Grant; or (b) insert the text "None".
+
+3. To specify a Change Date.
+
+4. Not to modify this License in any other way.
+
+-----------------------------------------------------------------------------
+
+Notice
+
+The Business Source License (this document, or the "License") is not an Open
+Source license. However, the Licensed Work will eventually be made available
+under an Open Source License, as stated in this License.


### PR DESCRIPTION
Adding a template for our LICENSE file to be deployed to all rust repositories.

Assumptions:
- ~~We'll be releasing under v0 at first~~
- ~~Change date for v0 will be at 2024-12-01 (or should we set it to 2025-01-01?)~~
- ~~Change date for all minor / fix releases under V0 will be listed in the repositories inside the `license/v0-license-date` file~~
- ~~When releasing v1, we'll be updating all svc repo's through Terraform again with a new LICENSE file~~

Questions:
- Do we actually want to keep the major version in sync for all our rust repo's? (or will they have their own release cycle and do we want to provide the LICENSE file trough the template repository instead)
  - Answer: The LICENSE `Change Date` Parameter has been updated to use more generic wording so we don't need to update the text for each release.
- Does it make sense to use a `license/v<version>-license-date` file to track change dates for minor/ fix releases? (Uniswap seems to be using some .eth address for this, but not sure how that'll work).
  - Answer: The License `Change Date` Parameter has been updated to use the README.md files as a place for all repositories to provide alternative change dates if needed.