### PR TITLE
feat: add cargo tarpaulin to Makefile and workflow

### DIFF
--- a/src/templates/all/.cspell.config.yaml
+++ b/src/templates/all/.cspell.config.yaml
@@ -21,3 +21,4 @@ ignorePaths:
   - '*/**Makefile'
   - 'target'
   - 'out'
+  - 'coverage'

--- a/src/templates/rust-all/.github/workflows/rust_ci.yml
+++ b/src/templates/rust-all/.github/workflows/rust_ci.yml
@@ -53,3 +53,18 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - run: make rust-clippy
+
+  # Validates the code examples in doc comments
+  doc:
+    name: Rustdoc
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - run: make rust-doc
+
+  coverage:
+    name: Unit Test Coverage
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - run: make rust-coverage || true

--- a/src/templates/rust-all/.github/workflows/rust_ci.yml
+++ b/src/templates/rust-all/.github/workflows/rust_ci.yml
@@ -65,6 +65,13 @@ jobs:
   coverage:
     name: Unit Test Coverage
     runs-on: ubuntu-latest
+    env:
+      NODE_COVERALLS_DEBUG: 1
     steps:
       - uses: actions/checkout@v2
       - run: make rust-coverage || true
+      - uses: coverallsapp/github-action@master
+        with:
+          github-token: ${{ secrets.github_token }}
+          path-to-lcov: coverage/lcov.info
+          base-path: .

--- a/src/templates/rust-all/.gitignore.tftpl
+++ b/src/templates/rust-all/.gitignore.tftpl
@@ -41,3 +41,7 @@ log/
 
 # Outputs
 out/
+
+# Coverage output
+coverage/
+*.profraw


### PR DESCRIPTION
NOTE: Tarpaulin requires `--security-opt seccomp=unconfined`, investigating if this is going to be a security issue if we only use it in GitHub actions for coverage tests and NOT deployment

UPDATE:

Moving this back out of draft, the `svc-devops-test` repo is very helpful

Demonstrated what UT coverage looks like: https://github.com/Arrow-air/svc-devops-test/pull/24
Output on Coveralls: https://coveralls.io/github/Arrow-air/svc-devops-test (log in to see source code)