### PR TITLE
feat: add api generation commands

### DIFF
--- a/src/repositories_rust.tf
+++ b/src/repositories_rust.tf
@@ -42,7 +42,10 @@ locals {
         },
         ".github/workflows/release.yml" = {
           content = file("templates/rust-svc/.github/workflows/release.yml")
-        }
+        },
+        ".github/workflows/api_docs.yml" = {
+          content = file("templates/rust-svc/.github/workflows/api_docs.yml")
+        },
       }
     )
 

--- a/src/templates/all/.cspell.config.yaml
+++ b/src/templates/all/.cspell.config.yaml
@@ -20,3 +20,4 @@ ignorePaths:
   - '*.svg'
   - '*/**Makefile'
   - 'target'
+  - 'out'

--- a/src/templates/all/.make/rust.mk
+++ b/src/templates/all/.make/rust.mk
@@ -123,7 +123,7 @@ rust-validate-openapi: rust-openapi
 		jeanberu/swagger-cli \
 		swagger-cli validate /out/$(PACKAGE_NAME)-openapi.json
 
-rust-grpc-api: check-cargo-registry rust-docker-pull
+rust-grpc-api:
 	@echo "$(CYAN)Generating GRPC documentation...$(SGR0)"
 	mkdir -p $(OUTPUTS_PATH)
 	@docker run \

--- a/src/templates/all/.make/rust.mk
+++ b/src/templates/all/.make/rust.mk
@@ -9,6 +9,7 @@ CARGO_INCREMENTAL   ?= 1
 RUSTC_BOOTSTRAP     ?= 0
 RELEASE_TARGET      ?= x86_64-unknown-linux-musl
 PUBLISH_DRY_RUN     ?= 1
+OUTPUTS_PATH        ?= $(SOURCE_PATH)/out
 
 # function with a generic template to run docker with the required values
 # Accepts $1 = command to run, $2 = additional command flags (optional)
@@ -109,6 +110,29 @@ rust-fmt: check-cargo-registry rust-docker-pull
 rust-tidy: check-cargo-registry rust-docker-pull
 	@echo "$(CYAN)Running rust file formatting fixes...$(SGR0)"
 	@$(call cargo_run,fmt,--all)
+
+rust-openapi: check-cargo-registry rust-docker-pull rust-build
+	@echo "$(CYAN)Generating openapi documentation...$(SGR0)"
+	mkdir -p $(OUTPUTS_PATH)
+	@$(call cargo_run,run,-- --openapi ./out/$(PACKAGE_NAME)-openapi.json)
+
+rust-validate-openapi: rust-openapi
+	@docker run \
+		--rm \
+		-v $(OUTPUTS_PATH):/out \
+		jeanberu/swagger-cli \
+		swagger-cli validate /out/$(PACKAGE_NAME)-openapi.json
+
+rust-grpc-api: check-cargo-registry rust-docker-pull
+	@echo "$(CYAN)Generating GRPC documentation...$(SGR0)"
+	mkdir -p $(OUTPUTS_PATH)
+	@docker run \
+		--rm \
+		--user `id -u`:`id -g` \
+		-v $(SOURCE_PATH)/proto:/protos \
+		-v $(OUTPUTS_PATH):/out \
+		pseudomuto/protoc-gen-doc \
+		--doc_opt=json,$(PACKAGE_NAME)-grpc-api.json
 
 rust-test-all: rust-build rust-check rust-test rust-clippy rust-fmt
 rust-all: rust-clean rust-test-all rust-release

--- a/src/templates/rust-all/.gitignore.tftpl
+++ b/src/templates/rust-all/.gitignore.tftpl
@@ -38,3 +38,6 @@ Cargo.lock
 
 # Logger Output
 log/
+
+# Outputs
+out/

--- a/src/templates/rust-svc/.github/workflows/api_docs.yml
+++ b/src/templates/rust-svc/.github/workflows/api_docs.yml
@@ -1,0 +1,47 @@
+## DO NOT EDIT!
+# This file was provisioned by Terraform
+# File origin: https://github.com/Arrow-air/tf-github/tree/main/src/templates/rust-svc/.github/workflows/api_docs.yml
+
+on:
+  push:
+    branches:
+    - main
+  pull_request:
+
+name: API Documentation
+
+env:
+  TERM: xterm
+
+jobs:
+  openapi:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Check for openapi spec
+        id: openapi_files
+        uses: andstor/file-existence-action@v2
+        with:
+          files: "openapi/*.rs"
+
+      - name: Generate & validate openapi json
+        if: steps.openapi_files.outputs.files_exists == 'true'
+        run: make rust-validate-openapi
+
+  grpc_api:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Check for proto files
+        id: grpc_api_files
+        uses: andstor/file-existence-action@v2
+        with:
+          files: "proto/*.proto"
+
+      - name: Generate grpc json file
+        if: steps.grpc_api_files.outputs.files_exists == 'true'
+        run: make rust-grpc-api


### PR DESCRIPTION
NOTE: Does not push to AWS or regenerate Docusaurus docs yet.

Example: https://github.com/Arrow-air/svc-cargo/actions/runs/3833748192/jobs/6525498455

This would allow REST API generation like so: https://github.com/Arrow-air/svc-cargo/blob/0ffdaf6299e2aad4bbf2a3abcfc71a37c362d1ed/server/src/main.rs#L175
