### PR TITLE
feat: add lib-ccsds

### DIFF
--- a/.cspell.project-words.txt
+++ b/.cspell.project-words.txt
@@ -29,4 +29,4 @@ healthcheck
 Nuxt
 nuxt
 vertiport
-
+ccsds

--- a/src/repositories_rust.tf
+++ b/src/repositories_rust.tf
@@ -20,6 +20,9 @@ locals {
       },
       "common" = {
         description = "Common functions and data types for Arrow services."
+      },
+      "ccsds" = {
+        description = "CCSDS Space Packet Protocol in Rust."
       }
       #   "analytics" = {
       #     description = "Fleet Routing Analysis from Real or Simulated Artifacts"


### PR DESCRIPTION
The initial implementation of ccsds.rs at https://github.com/Arrow-air/svc-telemetry/pull/2 raised some questions.

`lib-ccsds` should be `#![no_std]` by default so it can be used in safety-critical RTOS (disable heap allocation)

The implementation at  https://github.com/Arrow-air/svc-telemetry/pull/2 should be offered through a `std` feature.