### PR TITLE
fix(rust-svc): prevent double trigger release workflow

### DIFF
--- a/src/templates/rust-svc/.github/workflows/release.yml
+++ b/src/templates/rust-svc/.github/workflows/release.yml
@@ -5,7 +5,9 @@
 name: Tag and Release
 
 on:
-  push:
+  pull_request:
+    types:
+      - closed
     branches:
       - 'main'
       - 'develop'
@@ -15,6 +17,7 @@ env:
 
 jobs:
   prepare:
+    if: github.event.pull_request.merged == true
     name: Create Tag and Release notes
     permissions:
       contents: write


### PR DESCRIPTION
Seems like the `push` event gets triggered both on the merge commit and the last commit of the merge itself. Using the pull request `close` event now, but making sure it's closed with a merge before we run.