### PR TITLE
feat: svc-telemetry custom docker compose

### DIFF
--- a/src/repositories_rust.tf
+++ b/src/repositories_rust.tf
@@ -74,7 +74,7 @@ locals {
       "storage" = {
         description = "Storage module"
         # Override files list to provision with Terraform
-        # svc-storage handles it's own docker-compose.yml file
+        # svc-storage handles its own docker-compose.yml file
         # due to extra backend services needed
         files = merge(
           local.rust_default.files, {
@@ -116,6 +116,19 @@ locals {
       },
       "telemetry" = {
         description = "Receive and rebroadcast vehicle and vertiport telemetry."
+        # Override files list to provision with Terraform
+        # svc-telemetry handles its own docker-compose.yml file
+        # due to extra backend services needed
+        files = merge(
+          local.rust_default.files, {
+            "Dockerfile" = {
+              content = file("templates/rust-svc/Dockerfile")
+            },
+            ".github/workflows/release.yml" = {
+              content = file("templates/rust-svc/.github/workflows/release.yml")
+            }
+          }
+        )
       }
       "devops-test" = {
         description = "Repository used by devops to test workflows before rolling out to all other svc repositories"

--- a/src/repositories_rust.tf
+++ b/src/repositories_rust.tf
@@ -126,7 +126,19 @@ locals {
             },
             ".github/workflows/release.yml" = {
               content = file("templates/rust-svc/.github/workflows/release.yml")
-            }
+            },
+            ".github/workflows/post_release.yml" = {
+              content = file("templates/rust-svc/.github/workflows/post_release.yml")
+            },
+            ".github/workflows/autoupdate.yml" = {
+              content = file("templates/rust-svc/.github/workflows/autoupdate.yml")
+            },
+            ".github/workflows/autosquash.yml" = {
+              content = file("templates/rust-svc/.github/workflows/autosquash.yml")
+            },
+            ".github/workflows/api_docs.yml" = {
+              content = file("templates/rust-svc/.github/workflows/api_docs.yml")
+            },
           }
         )
       }


### PR DESCRIPTION
`svc-telemetry` needs to define its own docker-compose file due to dependencies on Redis