### PR TITLE
fix(editorconfig): don't test spaces for Cargo.lock file

### DIFF
--- a/src/templates/all/.editorconfig
+++ b/src/templates/all/.editorconfig
@@ -14,19 +14,15 @@ indent_size = 4
 # denotes a line break in Markdown
 indent_size = off
 trim_trailing_whitespace = false
-[{*.yml,*.yaml,*.toml}]
-indent_size = 2
 [*.rs]
 trim_trailing_whitespace = false
 indent_style = space
 indent_size = 4
-[{*.tf,*.hcl}]
-indent_size = 2
 [{Makefile*,*.mk,*.sh}]
 indent_style = tab
 indent_size = 4
-[{*.tsx,*.html,*.yml,*.yaml,*.toml,*.json}]
+[{*.tsx,*.html,*.yml,*.yaml,*.toml,*.json,*.tf,*.hcl}]
 indent_size = 2
 # we might want to use https://www.npmjs.com/package/lintspaces instead, we can't lint the css and js comments atm
-[{*.js,*.css}]
+[{*.js,*.css,Cargo.lock}]
 indent_size = unset


### PR DESCRIPTION
The latest mstruebing/editorconfig-checker docker image was [failing on the Cargo.lock file](https://github.com/Arrow-air/svc-storage/actions/runs/4152748810/jobs/7184132353). Where it seems to have ignored the file in the past, it now also started checking it and expecting 4 spaces as ident.
This pr should fix the issue.
