### PR TITLE
fix(rust-svc): grpc client publish

### DIFF
--- a/src/templates/all/.make/rust.mk
+++ b/src/templates/all/.make/rust.mk
@@ -73,7 +73,7 @@ rust-release: check-cargo-registry rust-docker-pull
 	@echo "$(CYAN)Running cargo build --release...$(SGR0)"
 	@$(call cargo_run,build,--release --target $(RELEASE_TARGET))
 
-rust-publish: check-cargo-registry rust-docker-pull
+rust-publish: rust-build
 	@echo "$(CYAN)Running cargo publish --package $(PUBLISH_PACKAGE_NAME)...$(SGR0)"
 ifeq ("$(PUBLISH_DRY_RUN)", "0")
 	@echo $(call cargo_run,publish,--package $(PUBLISH_PACKAGE_NAME) --target $(RELEASE_TARGET))

--- a/src/templates/rust-svc/.github/workflows/release.yml
+++ b/src/templates/rust-svc/.github/workflows/release.yml
@@ -11,13 +11,14 @@ on:
     branches:
       - 'main'
       - 'develop'
+  workflow_dispatch:
 
 env:
   TERM: xterm
 
 jobs:
   prepare:
-    if: github.event.pull_request.merged == true
+    if: github.event.pull_request.merged == true || github.event_name == 'workflow_dispatch'
     name: Create Tag and Release notes
     permissions:
       contents: write


### PR DESCRIPTION
Make sure we have all build output files available before creating the client-grpc publish package.
Also adds a `workflow_dispatch` trigger on the release workflow to manually trigger a release on the develop branch.