### PR TITLE
fix: markdown link check

### DIFF
--- a/src/templates/all/.make/markdown.mk
+++ b/src/templates/all/.make/markdown.mk
@@ -25,6 +25,6 @@ endif
 		--user `id -u`:`id -g` \
 		-w "/usr/src/app" \
 		-v "$(PWD):/usr/src/app" \
-		-t ghcr.io/tcort/markdown-link-check:stable \
+		-t ghcr.io/tcort/markdown-link-check:3.10 \
 		-c $(LINK_CHECKER_JSON) $(MARKDOWN_FILES)
 endif


### PR DESCRIPTION
The 'stable' version doesn't properly use the config file at the moment. Pinning to an older, still working, version.