### PR TITLE
fix(rust-svc): rebase steps in release process

### DIFF
--- a/src/templates/rust-svc/.github/workflows/release.yml
+++ b/src/templates/rust-svc/.github/workflows/release.yml
@@ -69,6 +69,7 @@ jobs:
         if: ${{ github.ref_name == 'develop' }}
         run: |
           git rebase -i --autosquash origin/main
+        continue-on-error: true
         env:
           GIT_AUTHOR_NAME: ${{ steps.import-gpg.outputs.name }}
           GIT_AUTHOR_EMAIL: ${{ steps.import-gpg.outputs.email }}
@@ -155,12 +156,13 @@ jobs:
           draft: false
           prerelease: ${{ github.ref_name == 'develop' }}
 
-      - name: Rebase develop branch
+      - name: Reset develop branch to main
         if: ${{ github.ref_name == 'main' }}
         run: |
           git checkout develop
-          git pull --rebase origin main
+          git reset --hard origin/main
           git push -f
+        continue-on-error: true
         env:
           GIT_AUTHOR_NAME: ${{ steps.import-gpg.outputs.name }}
           GIT_AUTHOR_EMAIL: ${{ steps.import-gpg.outputs.email }}


### PR DESCRIPTION
- Added `continue-on-error` for rebase auto squash step on develop branch. It will not fail the release process anymore. Any failed rebases can be manually fixed afterward if needed.
- Fixes rebase step on main branch merge. Will now reset develop branch to origin/main instead.