### PR TITLE
fix(tf-github): workflow missing DOCKER_NAME

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,8 @@
 # This file was provisioned by Terraform
 # File origin: https://github.com/Arrow-air/tf-github/tree/main/src/templates/tf-all/Makefile
 
+DOCKER_NAME := arrow-tf-github
+
 help: .help-base .help-cspell .help-markdown .help-editorconfig .help-tf
 
 include .make/base.mk

--- a/src/templates/tf-all/Makefile
+++ b/src/templates/tf-all/Makefile
@@ -2,6 +2,8 @@
 # This file was provisioned by Terraform
 # File origin: https://github.com/Arrow-air/tf-github/tree/main/src/templates/tf-all/Makefile
 
+DOCKER_NAME := arrow-${name}
+
 help: .help-base .help-cspell .help-markdown .help-editorconfig .help-tf
 
 include .make/base.mk


### PR DESCRIPTION
Fixing missing DOCKER_NAME for tf-github and tf-onboarding after changes made in https://github.com/Arrow-air/tf-github/pull/108