### PR TITLE
feat: add flash capability to STM32

### DIFF
--- a/src/repositories_embedded.tf
+++ b/src/repositories_embedded.tf
@@ -35,7 +35,10 @@ locals {
       },
       ".make/st.mk" = {
         content = file("templates/stm32-all/.make/st.mk")
-      }
+      },
+      "LICENSE" = {
+        content = file("templates/stm32-all/LICENSE")
+      },
     })
 
     repos = {

--- a/src/templates/stm32-all/.gitignore
+++ b/src/templates/stm32-all/.gitignore
@@ -1,9 +1,10 @@
 ## DO NOT EDIT!
 # This file was provisioned by Terraform
-# File origin: https://github.com/Arrow-air/tf-github/tree/main/src/templates/rust-svc/.env.base.tftpl
+# File origin: https://github.com/Arrow-air/tf-github/tree/main/src/templates/stm32-all/.env.base.tftpl
 
 CMakeCache.*
 CMakeFiles
 cmake_install.cmake
 *.swp
 build/
+.env

--- a/src/templates/stm32-all/.make/st.mk
+++ b/src/templates/stm32-all/.make/st.mk
@@ -4,27 +4,33 @@
 #
 BUILD_IMAGE_NAME     ?= ghcr.io/arrow-air/tools/arrow-stm32
 BUILD_IMAGE_TAG      ?= 1.0
-OUTPUTS_PATH        ?= $(SOURCE_PATH)/out
-ADDITIONAL_OPT      ?=
+OUTPUTS_PATH         ?= $(SOURCE_PATH)/out
+ADDITIONAL_OPT       ?=
 
 build_run = docker run \
-	--name=$(BUILD_IMAGE_NAME)-$@ \
+	--name=$(DOCKER_NAME)-$@ \
 	--rm \
+	--privileged \
 	--user `id -u`:`id -g` \
 	--workdir=/usr/src/app/ \
 	--env-file=$(SOURCE_PATH)/.env \
+	-v /dev/bus/usb:/dev/bus/usb \
 	$(ADDITIONAL_OPT) \
 	-v "$(SOURCE_PATH)/:/usr/src/app/" \
 	-t $(BUILD_IMAGE_NAME):$(BUILD_IMAGE_TAG) \
-	/bin/bash -c "$(1)"
+	/bin/sh -c "$(1)"
 
 build-docker-pull:
 	@echo docker pull -q $(BUILD_IMAGE_NAME):$(BUILD_IMAGE_TAG)
 
 .help-st:
 	@echo ""
-	@echo "$(SMUL)$(BOLD)$(GREEN)Build Container$(SGR0)"
-	@echo "  $(BOLD)build$(SGR0)       -- Run 'cmake'"
+	@echo "$(SMUL)$(BOLD)$(GREEN)STM32 Tools$(SGR0)"
+	@echo "  $(BOLD)stm32-build$(SGR0)       -- Run 'cmake'"
+	@echo "  $(BOLD)stm32-clean$(SGR0)       -- Removes the build/ directory"
+	@echo "  $(BOLD)stm32-flash$(SGR0)       -- Run 'st-flash write $(PROJECT_NAME).bin 0x08000000'"
+	@echo "  $(BOLD)stm32-probe$(SGR0)       -- Detects connected boards"
+	@echo "  $(BOLD)stm32-test$(SGR0)        -- Runs tests"
 
 .SILENT: build-docker-pull
 
@@ -34,12 +40,20 @@ stm32-build: build-docker-pull
 	@$(call build_run,cmake -B build/)
 	@$(call build_run,cd build && make $(PROJECT_NAME))
 
-stm32-flash: build-docker-pull build
-	@echo "$(YELLOW)Flashing tool not implemented. Skipping.$(SGR0)"
+stm32-probe: build-docker-pull
+	@echo "$(YELLOW)Detecting STM32 boards...$(SGR0)"
+	@$(call build_run,cd build && st-info probe)
+
+stm32-flash: build-docker-pull stm32-build
+	@echo "$(YELLOW)Flashing...$(SGR0)"
+	@$(call build_run,\
+	cd build && \
+	st-flash write $(PROJECT_NAME).bin 0x08000000 && \
+	st-flash reset)
 
 stm32-test:build-docker-pull
 	@echo "$(YELLOW)Testing framework not implemented. Skipping.$(SGR0)"
 
 stm32-clean: build-docker-pull
-	@echo "$(CYAN)Cleaning project...$(SGR0)"
-	@$(call build_run,cd build && make clean)
+	@echo "$(CYAN)Removing build directory...$(SGR0)"
+	@$(call build_run,rm -rf build/)

--- a/src/templates/stm32-all/LICENSE
+++ b/src/templates/stm32-all/LICENSE
@@ -1,7 +1,11 @@
-Copyright 2023 Arrow DAO
+Copyright (c) 2023 Arrow DAO
 
-Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the “Software”), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
 
-The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
 
-THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote products derived from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS “AS IS” AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/src/templates/stm32-all/Makefile
+++ b/src/templates/stm32-all/Makefile
@@ -5,8 +5,9 @@
 include .make/env.mk
 export
 
-help: .help-base .help-cspell .help-markdown .help-editorconfig .help-commitlint
+help: .help-base .help-cspell .help-markdown .help-editorconfig .help-commitlint .help-st
 build: stm32-build
+flash: stm32-flash
 clean: stm32-clean
 test: stm32-test cspell-test md-test-links editorconfig-test
 tidy: editorconfig-tidy


### PR DESCRIPTION
Adding BSD-3 license because of a HAL conf file acquired from STMicro: https://github.com/Arrow-air/embedded-template-stm32/blob/bc72fc4facdd25c1b8cc6a750c44793284de46d1/stm32f4xx_hal_conf.h