### PR TITLE
fix(rust): lib coverage tests and release

### DIFF
--- a/src/repositories_rust.tf
+++ b/src/repositories_rust.tf
@@ -23,6 +23,9 @@ locals {
       }
       "common" = {
         description = "Common functions and data types for Arrow services."
+        variables = {
+          "RELEASE_COMMIT_FILES" = ".terraform_init lib/Cargo.toml arrow-macros/**/Cargo.toml CHANGELOG.md"
+        }
       }
       "ccsds" = {
         description = "CCSDS Space Packet Protocol in Rust."
@@ -42,6 +45,9 @@ locals {
           "AWS_S3_SERVICES_DOCS_ROLE"   = "prd-GitHubActionsDocs"
         }
       }
+    }
+    variables = {
+      "RELEASE_COMMIT_FILES" = ".terraform_init Cargo.lock client-*/Cargo.toml server/Cargo.toml CHANGELOG.md"
     }
     template_files = merge(local.rust_default.template_files, {
       ".env.base" = "templates/rust-svc/.env.base.tftpl"
@@ -255,6 +261,8 @@ module "repository_rust_lib" {
     }
   )
 
+  variables = merge(local.rust_svc.variables, try(each.value.variables, {}))
+
   # Settings with defaults
   owner_team            = each.value.owner_team
   visibility            = each.value.visibility
@@ -292,6 +300,7 @@ module "repository_rust_svc" {
   )
 
   environments = local.rust_svc.environments
+  variables    = merge(local.rust_svc.variables, try(each.value.variables, {}))
 
   # Settings with defaults
   owner_team            = each.value.owner_team

--- a/src/templates/all/.make/rust.mk
+++ b/src/templates/all/.make/rust.mk
@@ -153,7 +153,7 @@ rust-coverage: check-cargo-registry rust-docker-pull
 	@mkdir -p coverage/
 	@$(call cargo_run,tarpaulin,\
 		--workspace -l --include-tests --tests --no-fail-fast \
-		--all-features --out Lcov \
+		--all-features --skip-clean -t 600 --out Lcov \
 		--output-dir coverage/)
 	@sed -e "s/\/usr\/src\/app\///g" -i coverage/lcov.info
 

--- a/src/templates/rust-all/.github/workflows/release.yml
+++ b/src/templates/rust-all/.github/workflows/release.yml
@@ -111,7 +111,7 @@ jobs:
 
       - name: Commit and push release updates
         env:
-          CHANGED_FILES: ".terraform_init Cargo.lock client-grpc/Cargo.toml server/Cargo.toml CHANGELOG.md"
+          CHANGED_FILES: "${{ vars.RELEASE_COMMIT_FILES }}"
           GIT_AUTHOR_NAME: ${{ steps.import-gpg.outputs.name }}
           GIT_AUTHOR_EMAIL: ${{ steps.import-gpg.outputs.email }}
           GIT_COMMITTER_NAME: ${{ steps.import-gpg.outputs.name }}

--- a/src/templates/rust-all/.github/workflows/rust_ci.yml
+++ b/src/templates/rust-all/.github/workflows/rust_ci.yml
@@ -21,54 +21,86 @@ env:
   TERM: xterm
 
 jobs:
-  check:
-    name: Checks
-    runs-on: ubuntu-latest
-    if: ${{ !contains(github.event.head_commit.message, 'provisioned by terraform') }}
-    steps:
-      - uses: actions/checkout@v2
-      - run: make rust-check
-
-  build_and_test_debug:
-    name: Build & Test
-    runs-on: ubuntu-latest
-    if: ${{ !contains(github.event.head_commit.message, 'provisioned by terraform') }}
-    steps:
-      - uses: actions/checkout@v2
-      - name: Build
-        run: make build
-      - name: Test
-        run: make rust-test
-
   fmt:
     name: Rustfmt
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - run: make rust-fmt
+
+  check:
+    name: Checks
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: "rust-ci"
+          cache-directories: "${{ github.workspace }}/.cargo"
+      - run: make rust-check
+
+  build:
+    name: Build
+    needs: check
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: "rust-ci"
+          cache-directories: "${{ github.workspace }}/.cargo"
+      - run: make rust-build
+
+  test:
+    name: Test
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: "rust-ci"
+          cache-directories: "${{ github.workspace }}/.cargo"
+      - name: Test
+        run: make rust-test
 
   clippy:
     name: Clippy
+    needs: build
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
+      - uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: "rust-ci"
+          cache-directories: "${{ github.workspace }}/.cargo"
       - run: make rust-clippy
 
   # Validates the code examples in doc comments
   doc:
     name: Rustdoc
+    needs: build
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
+      - uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: "rust-ci"
+          cache-directories: "${{ github.workspace }}/.cargo"
       - run: make rust-doc
 
   coverage:
     name: Unit Test Coverage
+    needs: build
     runs-on: ubuntu-latest
     env:
       NODE_COVERALLS_DEBUG: 1
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
+      - uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: "rust-ci"
+          cache-directories: "${{ github.workspace }}/.cargo"
       - run: |
           mkdir -p coverage
           make rust-coverage | tee coverage/ut.txt


### PR DESCRIPTION
Added caching action, but still seems to compile when it shouldn't.
Increased tarpaulin timeout to 5 min so tests can continue to run even though they exceed the default 60sec due to recompile.
Also added a fix for library build-and-deploy action.