### PR TITLE
ci(rust): trigger on file changes instead of paths

### DIFF
--- a/src/templates/all/.make/markdown.mk
+++ b/src/templates/all/.make/markdown.mk
@@ -2,7 +2,7 @@
 # This file was provisioned by Terraform
 # File origin: https://github.com/Arrow-air/tf-github/tree/main/src/templates/all/.make/markdown.mk
 
-MARKDOWN_FILES ?= $(shell find . -type f -iname '*md' ! -iwholename "*./node_modules/*" ! -path "./build" ! -iwholename "*.terraform*" ! -iwholename "*.cargo/*")
+MARKDOWN_FILES ?= $(shell find . -type f -iname '*md' ! -iwholename "*./node_modules/*" ! -path "./build" ! -iwholename "*.terraform*" ! -iwholename "*.cargo/*" ! -iwholename "./target/*")
 LINK_CHECKER_JSON ?= .link-checker.config.json
 
 .help-markdown:

--- a/src/templates/rust-all/.github/workflows/rust_ci.yml
+++ b/src/templates/rust-all/.github/workflows/rust_ci.yml
@@ -8,12 +8,9 @@ on:
       - develop
       - main
     paths:
-      - server/**
-      - client-grpc/**
-      - client-rest/**
-      - src/**
-      - Cargo.lock
-      - Cargo.toml
+      - "**/*.rs"
+      - "Cargo.lock"
+      - "**/Cargo.toml"
 
 name: Rust Checks
 


### PR DESCRIPTION
Now that we also use this workflow for lib repo's, we should just check based on file name / extension.
Not all repositories have the same folder structure.