### PR TITLE
chore(rust-svc): speed up local build target

### DIFF
--- a/src/templates/all/.make/rust.mk
+++ b/src/templates/all/.make/rust.mk
@@ -16,6 +16,9 @@ PACKAGE_TEST_FEATURES    ?= ""
 PACKAGE_BUILD_FEATURES   ?= ""
 PACKAGE_RELEASE_FEATURES ?= ""
 
+# Can contain quotes, but we don't want quotes
+EXCLUSIVE_FEATURES_TEST  := $(shell echo ${EXCLUSIVE_FEATURES_TEST})
+
 # function with a generic template to run docker with the required values
 # Accepts $1 = command to run, $2 = additional command flags (optional)
 ifeq ("$(CARGO_MANIFEST_PATH)", "")

--- a/src/templates/rust-svc/.dockerignore
+++ b/src/templates/rust-svc/.dockerignore
@@ -1,0 +1,8 @@
+## DO NOT EDIT!
+# This file was provisioned by Terraform
+# File origin: https://github.com/Arrow-air/tf-github/tree/main/src/templates/rust-svc/.dockerignore
+
+logs/
+target/*
+.cargo/
+.git/

--- a/src/templates/rust-svc/Dockerfile
+++ b/src/templates/rust-svc/Dockerfile
@@ -11,7 +11,10 @@ COPY . /usr/src/app
 
 # perl and build-base are needed to build openssl, see:
 # https://github.com/openssl/openssl/blob/master/INSTALL.md#prerequisites
-RUN apk -U add perl build-base ; cd /usr/src/app ; cargo build --release --features=vendored-openssl,${PACKAGE_RELEASE_FEATURES}
+RUN apk -U add perl build-base
+RUN --mount=type=cache,target=/usr/local/cargo/registry \
+    cd /usr/src/app && \
+    cargo build --release --features=vendored-openssl,${PACKAGE_RELEASE_FEATURES}
 
 FROM --platform=$TARGETPLATFORM ghcr.io/grpc-ecosystem/grpc-health-probe:v0.4.14 AS grpc-health-probe
 

--- a/src/templates/rust-svc/Makefile
+++ b/src/templates/rust-svc/Makefile
@@ -6,7 +6,7 @@ include .make/env.mk
 export
 
 help: .help-base .help-rust .help-python .help-cspell .help-markdown .help-editorconfig .help-commitlint .help-toml .help-docker
-build: rust-build docker-build
+build: clean docker-build
 clean: rust-clean
 release: rust-release
 publish: rust-publish


### PR DESCRIPTION
Inspired by https://github.com/Arrow-air/tf-github/pull/122

Should speed up local builds using a docker cache mount for the `cargo/registry` and ignoring unneeded folders for `COPY`.