### PR TITLE
feat: run sanity, python, rust workflows on push

### DIFF
--- a/src/templates/all/.github/workflows/sanity_checks.yml
+++ b/src/templates/all/.github/workflows/sanity_checks.yml
@@ -11,6 +11,7 @@ on:
   push:
     branches:
       - main
+      - develop
   pull_request:
 
 jobs:

--- a/src/templates/rust-all/.github/workflows/python_ci.yml
+++ b/src/templates/rust-all/.github/workflows/python_ci.yml
@@ -3,6 +3,12 @@
 # File origin: https://github.com/Arrow-air/tf-github/tree/main/src/templates/rust-all/.github/workflows/python_ci.yml
 
 on:
+  push:
+    branches:
+      - develop
+      - main
+    paths:
+      - '**.py'
   pull_request:
     branches:
       - develop

--- a/src/templates/rust-all/.github/workflows/rust_ci.yml
+++ b/src/templates/rust-all/.github/workflows/rust_ci.yml
@@ -3,6 +3,14 @@
 # File origin: https://github.com/Arrow-air/tf-github/tree/main/src/templates/rust-all/.github/workflows/rust_ci.yml
 
 on:
+  push:
+    branches:
+      - develop
+      - main
+    paths:
+      - "**/*.rs"
+      - "Cargo.lock"
+      - "**/Cargo.toml"
   pull_request:
     branches:
       - develop

--- a/src/templates/rust-all/.github/workflows/sanity_checks.yml
+++ b/src/templates/rust-all/.github/workflows/sanity_checks.yml
@@ -8,6 +8,10 @@ env:
   TERM: xterm
 
 on:
+  push:
+    branches:
+      - develop
+      - main
   pull_request:
     branches:
       - develop


### PR DESCRIPTION
![image](https://github.com/Arrow-air/tf-github/assets/6334638/1115cf69-8740-4736-9991-def3acc28efd)

Python, Rust, and Sanity Checks were only running on the branches being merged into develop and main, but not develop and main themselves

https://github.com/Arrow-air/svc-cargo/actions