### PR TITLE
feat(rust-svc): add target for docker dev build

### DIFF
--- a/src/repositories_rust.tf
+++ b/src/repositories_rust.tf
@@ -124,7 +124,7 @@ locals {
       "compliance" = {
         description = "Communication with external regulatory bodies."
         # Override files list to provision with Terraform
-        # svc-compliance handles its own post_release file
+        # svc-compliance handles its own post_release and docker-compose.yml
         # due to region specific docker builds
         files = merge(
           local.rust_default.files, {
@@ -133,9 +133,6 @@ locals {
             }
             ".dockerignore" = {
               content = file("templates/rust-svc/.dockerignore")
-            }
-            "docker-compose.yml" = {
-              content = file("templates/rust-svc/docker-compose.yml")
             }
             ".github/workflows/autosquash.yml" = {
               content = file("templates/rust-all/.github/workflows/autosquash.yml")

--- a/src/templates/all/.make/docker.mk
+++ b/src/templates/all/.make/docker.mk
@@ -3,6 +3,7 @@
 # File origin: https://github.com/Arrow-air/tf-github/tree/main/src/templates/all/.make/docker.mk
 
 DOCKER_BUILD_PATH ?= .
+DOCKER_DEV_FEATURES ?= ""
 
 .help-docker:
 	@echo ""
@@ -13,6 +14,9 @@ DOCKER_BUILD_PATH ?= .
 
 docker-build:
 	@DOCKER_BUILDKIT=1 docker build --build-arg PACKAGE_NAME=$(PACKAGE_NAME) --tag $(PACKAGE_NAME):latest $(DOCKER_BUILD_PATH)
+
+docker-build-dev:
+	@DOCKER_BUILDKIT=1 docker build --build-arg PACKAGE_NAME=$(PACKAGE_NAME) --build-arg ENABLE_FEATURES=${DOCKER_DEV_FEATURES} --tag $(PACKAGE_NAME):dev $(DOCKER_BUILD_PATH)
 
 docker-run: docker-stop
 	# Run docker container as a daemon and map a port

--- a/src/templates/all/.make/rust.mk
+++ b/src/templates/all/.make/rust.mk
@@ -117,6 +117,7 @@ rust-example-%: check-cargo-registry check-logs-dir rust-docker-pull
 		-e SERVER_PORT_GRPC=$(DOCKER_PORT_GRPC) \
 		-e SERVER_PORT_REST=$(DOCKER_PORT_REST) \
 		-e SERVER_HOSTNAME=$(DOCKER_NAME)-web-server \
+		-e DOCKER_IMAGE_TAG=dev \
 		example ; docker compose down
 
 rust-clippy: check-cargo-registry rust-docker-pull
@@ -165,6 +166,7 @@ rust-it-coverage: check-cargo-registry check-logs-dir rust-docker-pull
 		-e SERVER_PORT_GRPC=$(DOCKER_PORT_GRPC) \
 		-e SERVER_PORT_REST=$(DOCKER_PORT_REST) \
 		-e SERVER_HOSTNAME=$(DOCKER_NAME)-web-server \
+		-e DOCKER_IMAGE_TAG=latest \
 		it-coverage ; docker compose down
 
 rust-ut-coverage: ADDITIONAL_OPT = --security-opt seccomp='unconfined'

--- a/src/templates/rust-svc/.github/workflows/post_release.yml
+++ b/src/templates/rust-svc/.github/workflows/post_release.yml
@@ -113,10 +113,12 @@ jobs:
         with:
           images: ${{ env.DOCKER_IMAGE }}
           tags: |
+            type=edge,branch=main
             type=ref,event=branch
-            type=ref,event=pr
+            type=ref,event=workflow_dispatch
             type=semver,pattern=v{{version}},value=${{ github.ref_name }}
             type=semver,pattern=v{{major}}.{{minor}},value=${{ github.ref_name }}
+            type=semver,pattern=v{{major}},value=${{ github.ref_name }}
 
       - name: Build and push Docker image
         uses: docker/build-push-action@v3

--- a/src/templates/rust-svc/Dockerfile
+++ b/src/templates/rust-svc/Dockerfile
@@ -5,7 +5,7 @@ FROM --platform=$BUILDPLATFORM ghcr.io/arrow-air/tools/arrow-rust:1.2 AS build
 
 ENV CARGO_INCREMENTAL=1
 ENV RUSTC_BOOTSTRAP=0
-ENV PACKAGE_RELEASE_FEATURES=
+ARG ENABLE_FEATURES=
 
 COPY . /usr/src/app
 
@@ -14,9 +14,9 @@ COPY . /usr/src/app
 RUN apk -U add perl build-base
 RUN --mount=type=cache,target=/usr/local/cargo/registry \
     cd /usr/src/app && \
-    cargo build --release --features=vendored-openssl,${PACKAGE_RELEASE_FEATURES}
+    cargo build --release --features=vendored-openssl,${ENABLE_FEATURES}
 
-FROM --platform=$TARGETPLATFORM ghcr.io/grpc-ecosystem/grpc-health-probe:v0.4.14 AS grpc-health-probe
+FROM --platform=$TARGETPLATFORM ghcr.io/grpc-ecosystem/grpc-health-probe:v0.4.19 AS grpc-health-probe
 
 FROM --platform=$TARGETPLATFORM alpine:latest
 ARG PACKAGE_NAME=

--- a/src/templates/rust-svc/docker-compose.yml
+++ b/src/templates/rust-svc/docker-compose.yml
@@ -6,7 +6,7 @@ version: '3.6'
 services:
   web-server:
     container_name: ${DOCKER_NAME}-web-server
-    image: ${PACKAGE_NAME}:latest
+    image: ${PACKAGE_NAME}:${DOCKER_IMAGE_TAG}
     ports:
       - ${HOST_PORT_REST}:${DOCKER_PORT_REST}
       - ${HOST_PORT_GRPC}:${DOCKER_PORT_GRPC}


### PR DESCRIPTION
Adds `docker-build-dev` make target so we can build a docker image with the `stub_backends` feature enabled. This can then be used to run the `example` without the need of additional backends.

Merge after #136 

After apply the following repositories will need their docker-compose.yml files updated as well:
- svc-telemetry
- svc-gis
- svc-storage
- svc-compliance