### PR TITLE
feat(rust-all): add 'latest' tag on release

### DIFF
--- a/src/templates/rust-all/.github/workflows/release.yml
+++ b/src/templates/rust-all/.github/workflows/release.yml
@@ -52,8 +52,10 @@ jobs:
           then
             echo "CUSTOM_RELEASE_RULES=fix:prerelease,feat:prerelease,chore:prerelease" >> $GITHUB_ENV
             echo "RELEASE_COMMIT_MESSAGE=fixup! ci: update release files\n\n[skip ci]" >> $GITHUB_ENV
+            echo "LATEST_TAG=latest-${GITHUB_REF_NAME}" >> $GITHUB_ENV
           else
             echo "RELEASE_COMMIT_MESSAGE=ci: update release files\n\n[skip ci]" >> $GITHUB_ENV
+            echo "LATEST_TAG=latest" >> $GITHUB_ENV
           fi
 
       - name: Determine new Tag
@@ -129,14 +131,20 @@ jobs:
           # set COMMIT_SHA env var with new current sha as it is used for tagging in the next step
           echo "COMMIT_SHA=$(git rev-parse --verify HEAD)" >> $GITHUB_ENV
 
-      - name: Set and Push New Tag
-        uses: mathieudutour/github-tag-action@v6.1
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          custom_tag: ${{ steps.tag_version.outputs.new_version }}
-          commit_sha: ${{ env.COMMIT_SHA }}
+      - name: Set and Push New Tags
+        env:
+          GIT_AUTHOR_NAME: ${{ steps.import-gpg.outputs.name }}
+          GIT_AUTHOR_EMAIL: ${{ steps.import-gpg.outputs.email }}
+          GIT_COMMITTER_NAME: ${{ steps.import-gpg.outputs.name }}
+          GIT_COMMITTER_EMAIL: ${{ steps.import-gpg.outputs.email }}
+          GIT_SEQUENCE_EDITOR: ':'
+        continue-on-error: true
+        run: |
+          git tag v${{ steps.tag_version.outputs.new_version }} ${{ env.COMMIT_SHA }} -m ""
+          git tag -f ${{ env.LATEST_TAG }} ${{ env.COMMIT_SHA }} -m ""
+          git push -f --tags
 
-      - name: Generate Changelog base on new tag
+      - name: Generate Changelog based on new tag
         id: changelog_release
         uses: mrchief/universal-changelog-action@v1.3.2
         with:

--- a/src/templates/rust-svc/.github/workflows/post_release.yml
+++ b/src/templates/rust-svc/.github/workflows/post_release.yml
@@ -115,7 +115,7 @@ jobs:
           tags: |
             type=edge,branch=main
             type=ref,event=branch
-            type=ref,event=workflow_dispatch
+            type=match,pattern=v.*-(develop)\.\d,group=1,value=${{ github.ref_name }},prefix=latest-
             type=semver,pattern=v{{version}},value=${{ github.ref_name }}
             type=semver,pattern=v{{major}}.{{minor}},value=${{ github.ref_name }}
             type=semver,pattern=v{{major}},value=${{ github.ref_name }}


### PR DESCRIPTION
This adds the latest (main branch) and latest-develop (develop branch) tags to the git repositories if a release is done on the corresponding branch.
In addition, the docker image now also gets the latest-develop tag on develop releases