### PR TITLE
fix: cspell should not auto search additional config files

### DIFF
--- a/src/templates/all/.cspell.config.yaml
+++ b/src/templates/all/.cspell.config.yaml
@@ -24,3 +24,4 @@ ignorePaths:
   - "out"
   - "coverage"
   - "src/*.plan"
+noConfigSearch: true


### PR DESCRIPTION
An update from cspell has introduced in issue when running our automated checks, where additional configurations found in the child path would also be included.
This should fix that issue for us.