### PR TITLE
Fix naming of AIP repo

### DIFF
--- a/.cspell.project-words.txt
+++ b/.cspell.project-words.txt
@@ -1,3 +1,5 @@
+aip
+aips
 Arrowair
 bypassers
 CICD

--- a/src/main.tf
+++ b/src/main.tf
@@ -120,7 +120,7 @@ locals {
       visibility     = "public"
       owner_team     = "governance"
     }
-    "dao-aip" = {
+    "dao-aips" = {
       default_branch = "main"
       description    = "Arrowair DAO Arrow Improvement Proposals"
       visibility     = "public"


### PR DESCRIPTION
Per Sleety's request, the repo ought to be named `dao-aips`