### PR TITLE
feat: add project-spearhead repository

### DIFF
--- a/src/repositories_pod.tf
+++ b/src/repositories_pod.tf
@@ -42,6 +42,11 @@ locals {
         description = "Code and documentation for the flight tracking platform."
         webhooks    = {}
       }
+      "spearhead" = {
+        description = "Project Spearhead — hybrid propulsion VTOL platform."
+        owner_team  = "spearhead"
+        webhooks    = {}
+      }
     }
 
     settings = {


### PR DESCRIPTION
Adds `project-spearhead` to the pod projects, owned by the new `spearhead` team.

**Depends on:** Arrow-air/tf-onboarding#30 (team creation) — merge that first so Terraform Cloud can resolve the team reference.

**Repo:** `Arrow-air/project-spearhead`
**Description:** Project Spearhead — hybrid propulsion VTOL platform.
**Owner team:** `spearhead` (Alperen + Zeynep)