### PR TITLE
feat: add project-spearhead repository

### DIFF
--- a/src/repositories_pod.tf
+++ b/src/repositories_pod.tf
@@ -42,6 +42,11 @@ locals {
         description = "Code and documentation for the flight tracking platform."
         webhooks    = {}
       }
+      "spearhead" = {
+        description = "Project Spearhead documentation, designs, and project artifacts."
+        owner_team  = "spearhead"
+        webhooks    = {}
+      }
     }
 
     settings = {


### PR DESCRIPTION
Creates `project-spearhead` using the standard pod-project template.

- Owner team: `spearhead` (overrides pod default of `drone-engineering`)
- Visibility: public
- Template: standard pod-project (docs/, src/, ADRs, meeting notes, etc.)

Depends on the `spearhead` team being created via the corresponding tf-onboarding PR.