### PR TITLE
feat: add project-caribou repository

### DIFF
--- a/src/repositories_pod.tf
+++ b/src/repositories_pod.tf
@@ -47,6 +47,11 @@ locals {
         owner_team  = "spearhead"
         webhooks    = {}
       }
+      "caribou" = {
+        description = "Project Caribou documentation, designs, and project artifacts."
+        owner_team  = "caribou"
+        webhooks    = {}
+      }
     }
 
     settings = {


### PR DESCRIPTION
Creates `project-caribou` using the standard pod-project template.

- Owner team: `caribou` (overrides pod default of `drone-engineering`)
- Visibility: public
- Template: standard pod-project (docs/, src/, ADRs, meeting notes, etc.)

Depends on the `caribou` team being created via Arrow-air/tf-onboarding#32.