### PR TITLE
feat: add project-longshot repository

### DIFF
--- a/src/repositories_pod.tf
+++ b/src/repositories_pod.tf
@@ -54,6 +54,7 @@ locals {
       }
       "longshot" = {
         description = "Project Longshot documentation, designs, and project artifacts."
+        owner_team  = "longshot"
         webhooks    = {}
       }
     }

--- a/src/repositories_pod.tf
+++ b/src/repositories_pod.tf
@@ -52,6 +52,10 @@ locals {
         owner_team  = "caribou"
         webhooks    = {}
       }
+      "longshot" = {
+        description = "Project Longshot documentation, designs, and project artifacts."
+        webhooks    = {}
+      }
     }
 
     settings = {


### PR DESCRIPTION
Adds the Project Longshot repo (`project-longshot`) to the Arrow-air org as a pod project.

Uses the default `drone-engineering` owner team (same as Quiver, Feather, Flight Tracking). No custom team needed unless Julius wants one later.

Requested by Julius in Discord.