### PR TITLE
fix: stop managing pod docs templates

### DIFF
--- a/src/repositories_pod.tf
+++ b/src/repositories_pod.tf
@@ -21,12 +21,6 @@ locals {
       "docs/mkdocs.yaml" = {
         content = file("templates/pod-project/mkdocs.yaml")
       }
-      "docs/ADRs/template-adr.md" = {
-        content = file("templates/pod-project/template-adr.md")
-      }
-      "docs/meetings/template-meeting.md" = {
-        content = file("templates/pod-project/template-meeting.md")
-      }
     })
 
     repos = {


### PR DESCRIPTION
## Summary
- remove managed `docs/ADRs/template-adr.md` from pod project repos
- remove managed `docs/meetings/template-meeting.md` from pod project repos

## Why
These templates are useful when a repo is first created, but managing them forever means Terraform recreates the ADRs and meetings folders after a project intentionally deletes them.

## Validation
- `terraform fmt -check -recursive .` could not be run locally because Terraform is not installed on this host
- change is a straight deletion from `local.pod-projects.files` only
