### PR TITLE
feat: add arrow-catalog repository

### DIFF
--- a/src/main.tf
+++ b/src/main.tf
@@ -126,6 +126,15 @@ locals {
       visibility     = "public"
       owner_team     = "governance"
     }
+    "arrow-catalog" = {
+      default_branch = "main"
+      description    = "Canonical catalog data for Arrow products, manufacturers, and AIP-009 manufacturing protocol metadata"
+      visibility     = "public"
+      owner_team     = "governance"
+      collaborators = {
+        maintainers = ["drone-engineering", "webdevelopers"]
+      }
+    }
   }
 }
 


### PR DESCRIPTION
## Summary
- Add the public `arrow-catalog` repository to Terraform-managed GitHub repositories
- Set `governance` as the owner team
- Add `drone-engineering` and `webdevelopers` as maintainers for catalog/storefront collaboration

## Context
This repo will hold canonical catalog data for Arrow products, manufacturers, offers, checkout groups, and AIP-009 manufacturing protocol metadata. The website can consume this catalog for the MVP storefront while the catalog remains reviewable and eventually governable/on-chain.

## Validation
- Basic local syntax/string sanity check passed
- `terraform fmt` / `terraform validate` not run locally: Terraform/OpenTofu CLI is not installed on this host
