### PR TITLE
feat: add arrow-store repository

### DIFF
--- a/src/main.tf
+++ b/src/main.tf
@@ -135,6 +135,15 @@ locals {
         maintainers = ["drone-engineering", "webdevelopers"]
       }
     }
+    "arrow-store" = {
+      default_branch = "main"
+      description    = "Independent storefront app for Arrow products, manufacturers, and AIP-009 commerce workflows"
+      visibility     = "public"
+      owner_team     = "webdevelopers"
+      collaborators = {
+        maintainers = ["drone-engineering", "governance"]
+      }
+    }
   }
 }
 


### PR DESCRIPTION
## Summary
- Add the public `arrow-store` repository to Terraform-managed GitHub repositories
- Set `webdevelopers` as the owner team
- Add `drone-engineering` and `governance` as maintainer collaborators for store/catalog/AIP-009 coordination

## Context
`arrow-store` will be the independent storefront app for `store.arrowair.com`. It is intended to consume `arrow-catalog` data and own the commerce UX, private order workflow, manufacturer/admin views, and payment handoff for Arrow's AIP-009 manufacturing storefront.

## Validation
- Confirmed `Arrow-air/arrow-store` does not currently exist via `gh repo view`
- Terraform/OpenTofu CLI is not installed on this host, so local `terraform fmt`, `terraform validate`, and `terraform plan` could not be run
- This repository's PR workflow should generate the authoritative Terraform plan before merge
