### PR TITLE
chore: remove dead code and document repository management

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,13 +26,27 @@ As soon as the PR is merged to `main`, a workflow will run to deploy the changes
 All repositories are created through the internal `github-repository` module, allowing for easy management of branch protections, files and webhooks.
 Repositories that require similar settings, are grouped into separate files. The configurations provided by these `repositories_*.tf` files also enforce naming conventions.
 
-The following repository types are currently pre-defined:
- * `tf`  -- Repositories containing Terraform code
- * `lib-<name>-rust` -- Repositories for the Arrow libraries written in Rust
- * `svc-<name>-rust` -- Repositories for the Arrow services written in Rust
- * `lib-template-<lang>` -- Repository templates for Arrow libraries
- * `svc-template-<lang>` -- Repository templates for Arrow services
+The following repository groups are currently pre-defined:
+
+| File                         | Naming convention                                  | Description                                                  |
+| ---------------------------- | -------------------------------------------------- | ------------------------------------------------------------ |
+| `main.tf`                    | no prefix                                          | General repositories (website, DAO governance, services)     |
+| `repositories_terraform.tf`  | `tf-<name>`, `tf-gcp-<name>`, `terraform-<name>`   | Terraform configuration and shared module repositories       |
+| `repositories_pod.tf`        | `project-<name>`                                   | Arrow pod project repositories                               |
+| `repositories_embedded.tf`   | no prefix                                          | STM32 embedded projects                                      |
+| `repositories_templates.tf`  | `embedded-template-<name>`, `pod-template-<name>`  | Template repositories used to provision the groups above     |
+
+## Managed files
+
+The module provisions two kinds of files into repositories:
+ * `repository_files` -- fully managed by Terraform. Local changes are overwritten on the next apply. These files carry a `DO NOT EDIT` header.
+ * `seeded_repository_files` -- created with initial content when the repository is first provisioned, but owned by the repository afterwards. Terraform will not touch them again (e.g. `.cspell.config.yaml`).
 
 ## Adding a new repository
 
-:construction: Coming Soon :construction:
+1. Make sure the owning team exists. Teams are managed in the (private) `tf-onboarding` repository -- if the team is new, merge that change first, otherwise the plan here fails on the team lookup.
+2. Add the repository to the map in the matching `repositories_*.tf` file (or `local.repos` in `main.tf` for general repositories), providing at minimum a `description`, `visibility` and `owner_team`.
+3. Open a PR. The workflow posts the Terraform plan as a PR comment -- always review it before merging.
+4. Merge to `main`. The workflow applies the change automatically.
+
+Please note that branch protections are only applied to public repositories; they are not supported for private repositories on the current GitHub plan.

--- a/src/moved.tf
+++ b/src/moved.tf
@@ -1,7 +1,0 @@
-#################################################
-#
-# Temporary file to tell Terraform some resources
-# have been renamed in the state.
-# Can be removed after apply
-#
-#################################################

--- a/src/repositories_embedded.tf
+++ b/src/repositories_embedded.tf
@@ -55,7 +55,7 @@ locals {
       owner_team     = "embedded"
       visibility     = "public"
       default_branch = "develop"
-      webhooks       = try(local.webhooks["embedded"], {})
+      webhooks       = {}
       default_branch_protection_settings = {
         required_pull_request_reviews = {
           pull_request_bypassers = ["/arrow-github-bot"]

--- a/src/repositories_templates.tf
+++ b/src/repositories_templates.tf
@@ -14,7 +14,7 @@ locals {
         owner_team                         = "embedded"
         visibility                         = "public"
         default_branch                     = "develop"
-        webhooks                           = try(local.webhooks["embedded"], {})
+        webhooks                           = {}
         default_branch_protection_settings = {} # Using module defaults
       }
     }


### PR DESCRIPTION
## Summary

Cleanup-only PR, no resource changes expected (plan should be empty apart from refresh):

- Delete the empty `src/moved.tf` left over from a long-completed state migration.
- Remove the `try(local.webhooks["embedded"], {})` lookups in `repositories_embedded.tf` and `repositories_templates.tf` — no `embedded` webhook is defined, so the expression always silently resolved to `{}`. Now it says `{}` outright.
- README: replace the outdated repository type list (`lib-*-rust`/`svc-*-rust` no longer exist) with the actual repository groups, document the managed vs seeded file mechanisms introduced in #162, and fill in the long-standing 'Adding a new repository' placeholder — including the cross-repo ordering constraint that teams must exist in `tf-onboarding` before a repository here can reference them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)